### PR TITLE
rust: rros: create devices on boot automatically

### DIFF
--- a/kernel/rros/clock.rs
+++ b/kernel/rros/clock.rs
@@ -24,6 +24,7 @@ use core::ops::Deref;
 use core::ops::DerefMut;
 use core::{mem::align_of, mem::size_of, todo};
 use factory::RROS_CLONE_PUBLIC;
+use kernel::device::DeviceType;
 use kernel::file::File;
 use kernel::io_buffer::IoBufferWriter;
 use kernel::{
@@ -499,7 +500,7 @@ pub static mut CLOCK_LIST: List<*mut RrosClock> = List::<*mut RrosClock> {
 
 /*
 struct rros_factory rros_clock_factory = {
-    .name	=	RROS_CLOCK_DEV,
+    .name	=	clock,
     .fops	=	&clock_fops,
     .nrdev	=	CONFIG_RROS_NR_CLOCKS,
     .attrs	=	clock_groups,
@@ -508,15 +509,15 @@ struct rros_factory rros_clock_factory = {
 */
 pub static mut RROS_CLOCK_FACTORY: SpinLock<factory::RrosFactory> = unsafe {
     SpinLock::new(factory::RrosFactory {
-        name: unsafe { CStr::from_bytes_with_nul_unchecked("RROS_CLOCK_DEV\0".as_bytes()) },
-        // fops: Some(&ClockOps),
+        name: unsafe { CStr::from_bytes_with_nul_unchecked("clock\0".as_bytes()) },
+        // fops: Some(&Clockops),
         nrdev: CONFIG_RROS_NR_CLOCKS,
         build: None,
         dispose: Some(clock_factory_dispose),
         attrs: None, //sysfs::attribute_group::new(),
-        flags: 2,
+        flags: factory::RrosFactoryType::SINGLE,
         inside: Some(factory::RrosFactoryInside {
-            rrtype: None,
+            type_: DeviceType::new(),
             class: None,
             cdev: None,
             device: None,

--- a/kernel/rros/clock.rs
+++ b/kernel/rros/clock.rs
@@ -498,15 +498,6 @@ pub static mut CLOCK_LIST: List<*mut RrosClock> = List::<*mut RrosClock> {
     },
 };
 
-/*
-struct rros_factory rros_clock_factory = {
-    .name	=	clock,
-    .fops	=	&clock_fops,
-    .nrdev	=	CONFIG_RROS_NR_CLOCKS,
-    .attrs	=	clock_groups,
-    .dispose =	clock_factory_dispose,
-};
-*/
 pub static mut RROS_CLOCK_FACTORY: SpinLock<factory::RrosFactory> = unsafe {
     SpinLock::new(factory::RrosFactory {
         name: unsafe { CStr::from_bytes_with_nul_unchecked("clock\0".as_bytes()) },

--- a/kernel/rros/control.rs
+++ b/kernel/rros/control.rs
@@ -12,16 +12,14 @@ use kernel::{
     mm::{remap_pfn_range, PAGE_SHARED},
     prelude::*,
     str::CStr,
-    sync::{Lock, Mutex, SpinLock},
-    uidgid::{KgidT, KuidT},
-    user_ptr::{UserSlicePtr, UserSlicePtrWriter},
+    sync::{Mutex, SpinLock},
 };
 
 pub const CONFIG_RROS_NR_CONTROL: usize = 0;
 
 pub static mut RROS_CONTROL_FACTORY: SpinLock<RrosFactory> = unsafe {
     SpinLock::new(RrosFactory {
-        name: unsafe { CStr::from_bytes_with_nul_unchecked("control\0".as_bytes()) },
+        name: CStr::from_bytes_with_nul_unchecked("control\0".as_bytes()),
         nrdev: CONFIG_RROS_NR_CONTROL,
         build: None,
         dispose: None,

--- a/kernel/rros/monitor.rs
+++ b/kernel/rros/monitor.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 use kernel::{
-    bindings, c_types, prelude::*, spinlock_init, str::CStr, sync::SpinLock, user_ptr, Error, device::DeviceType,
+    c_types, prelude::*, spinlock_init, str::CStr, sync::SpinLock, user_ptr, Error, device::DeviceType,
 };
 
 use kernel::file::File;
@@ -309,7 +309,7 @@ pub fn monitor_factory_build(
 #[allow(dead_code)]
 pub static mut RROS_MONITOR_FACTORY: SpinLock<factory::RrosFactory> = unsafe {
     SpinLock::new(factory::RrosFactory {
-        name: unsafe { CStr::from_bytes_with_nul_unchecked("monitor\0".as_bytes()) },
+        name: CStr::from_bytes_with_nul_unchecked("monitor\0".as_bytes()),
         // fops: Some(&MonitorOps),
         nrdev: CONFIG_RROS_MONITOR,
         build: None,

--- a/kernel/rros/monitor.rs
+++ b/kernel/rros/monitor.rs
@@ -10,7 +10,9 @@ use crate::{
     wait::RrosWaitQueue,
 };
 
-use kernel::{c_types, prelude::*, spinlock_init, str::CStr, sync::SpinLock, user_ptr, Error};
+use kernel::{
+    bindings, c_types, prelude::*, spinlock_init, str::CStr, sync::SpinLock, user_ptr, Error, device::DeviceType,
+};
 
 use kernel::file::File;
 use kernel::file_operations::FileOperations;
@@ -307,15 +309,15 @@ pub fn monitor_factory_build(
 #[allow(dead_code)]
 pub static mut RROS_MONITOR_FACTORY: SpinLock<factory::RrosFactory> = unsafe {
     SpinLock::new(factory::RrosFactory {
-        name: CStr::from_bytes_with_nul_unchecked("RROS_MONITOR_DEV\0".as_bytes()),
+        name: unsafe { CStr::from_bytes_with_nul_unchecked("monitor\0".as_bytes()) },
         // fops: Some(&MonitorOps),
         nrdev: CONFIG_RROS_MONITOR,
         build: None,
         dispose: Some(monitor_factory_dispose),
         attrs: None, //sysfs::attribute_group::new(),
-        flags: 2,
+        flags: factory::RrosFactoryType::CLONE,
         inside: Some(factory::RrosFactoryInside {
-            rrtype: None,
+            type_: DeviceType::new(),
             class: None,
             cdev: None,
             device: None,

--- a/kernel/rros/proxy.rs
+++ b/kernel/rros/proxy.rs
@@ -19,8 +19,10 @@ use crate::{
 
 use kernel::{
     bindings,
+    device::DeviceType,
     file::File,
     file_operations::{FileOpener, FileOperations},
+    from_kernel_result,
     io_buffer::{IoBufferReader, IoBufferWriter},
     prelude::*,
     premmpt::running_inband,
@@ -1017,15 +1019,15 @@ fn proxy_factory_build(
 
 pub static mut RROS_PROXY_FACTORY: SpinLock<RrosFactory> = unsafe {
     SpinLock::new(RrosFactory {
-        name: CStr::from_bytes_with_nul_unchecked("RROS_PROXY_DEV\0".as_bytes()),
+        name: unsafe { CStr::from_bytes_with_nul_unchecked("proxy\0".as_bytes()) },
         // fops: Some(&RustFileProxy),
         nrdev: CONFIG_RROS_NR_PROXIES,
         build: Some(proxy_factory_build),
         dispose: Some(proxy_factory_dispose),
         attrs: None, //sysfs::attribute_group::new(),
-        flags: 1,
+        flags: crate::factory::RrosFactoryType::CLONE,
         inside: Some(RrosFactoryInside {
-            rrtype: None,
+            type_: DeviceType::new(),
             class: None,
             cdev: None,
             device: None,

--- a/kernel/rros/proxy.rs
+++ b/kernel/rros/proxy.rs
@@ -22,7 +22,6 @@ use kernel::{
     device::DeviceType,
     file::File,
     file_operations::{FileOpener, FileOperations},
-    from_kernel_result,
     io_buffer::{IoBufferReader, IoBufferWriter},
     prelude::*,
     premmpt::running_inband,

--- a/kernel/rros/thread.rs
+++ b/kernel/rros/thread.rs
@@ -8,10 +8,12 @@ use crate::{
     timer, RROS_OOB_CPUS,
 };
 use alloc::rc::Rc;
-use core::ops::DerefMut;
+use kernel::bindings::prepare_creds;
+use kernel::device::DeviceType;
+use kernel::ktime::ktime_sub;
+use core::ops::{Deref, DerefMut};
 use core::result::Result::Ok;
 use core::{cell::RefCell, clone::Clone};
-use kernel::bindings::prepare_creds;
 use kernel::completion::Completion;
 use kernel::cpumask::CpumaskT;
 use kernel::error::from_kernel_err_ptr;
@@ -19,7 +21,6 @@ use kernel::file::File;
 use kernel::file_operations::FileOperations;
 use kernel::io_buffer::IoBufferWriter;
 use kernel::irq_work::IrqWork;
-use kernel::ktime::ktime_sub;
 use kernel::str::CStr;
 use kernel::task::Task;
 #[warn(unused_mut)]
@@ -149,8 +150,8 @@ pub const CONFIG_RROS_NR_THREADS: usize = 16;
 
 pub static mut RROS_TRHEAD_FACTORY: SpinLock<factory::RrosFactory> = unsafe {
     SpinLock::new(factory::RrosFactory {
-        // TODO: move this and clock factory name to a variable
-        name: CStr::from_bytes_with_nul_unchecked("RROS_THREAD_DEV\0".as_bytes()),
+        // TODO: move this and clock factory name to a variable 
+        name: unsafe { CStr::from_bytes_with_nul_unchecked("thread\0".as_bytes()) },
         // fops: Some(&ThreadOps),
         nrdev: CONFIG_RROS_NR_THREADS,
         // TODO: add the corresponding ops
@@ -160,9 +161,9 @@ pub static mut RROS_TRHEAD_FACTORY: SpinLock<factory::RrosFactory> = unsafe {
         // TODO: add the corresponding attr
         attrs: None, //sysfs::attribute_group::new(),
         // TODO: rename this flags to the bit level variable RROS_FACTORY_CLONE and RROS_FACTORY_SINGLE
-        flags: 1,
+        flags: factory::RrosFactoryType::CLONE,
         inside: Some(factory::RrosFactoryInside {
-            rrtype: None,
+            type_: DeviceType::new(),
             class: None,
             cdev: None,
             device: None,

--- a/kernel/rros/thread.rs
+++ b/kernel/rros/thread.rs
@@ -11,7 +11,7 @@ use alloc::rc::Rc;
 use kernel::bindings::prepare_creds;
 use kernel::device::DeviceType;
 use kernel::ktime::ktime_sub;
-use core::ops::{Deref, DerefMut};
+use core::ops::DerefMut;
 use core::result::Result::Ok;
 use core::{cell::RefCell, clone::Clone};
 use kernel::completion::Completion;
@@ -151,7 +151,7 @@ pub const CONFIG_RROS_NR_THREADS: usize = 16;
 pub static mut RROS_TRHEAD_FACTORY: SpinLock<factory::RrosFactory> = unsafe {
     SpinLock::new(factory::RrosFactory {
         // TODO: move this and clock factory name to a variable 
-        name: unsafe { CStr::from_bytes_with_nul_unchecked("thread\0".as_bytes()) },
+        name: CStr::from_bytes_with_nul_unchecked("thread\0".as_bytes()),
         // fops: Some(&ThreadOps),
         nrdev: CONFIG_RROS_NR_THREADS,
         // TODO: add the corresponding ops

--- a/kernel/rros/xbuf.rs
+++ b/kernel/rros/xbuf.rs
@@ -24,10 +24,9 @@ use kernel::{
     irq_work::*,
     prelude::*,
     str::CStr,
-    sync::{ Lock, SpinLock },
-    uidgid::{KgidT, KuidT},
-    user_ptr::{ UserSlicePtr, UserSlicePtrReader, UserSlicePtrWriter },
-    vmalloc::{c_kzalloc, c_kzfree}, device::DeviceType,
+    sync::SpinLock,
+    user_ptr::{ UserSlicePtrReader, UserSlicePtrWriter },
+    vmalloc::c_kzalloc, device::DeviceType,
 };
 
 #[derive(Default)]

--- a/rust/kernel/chrdev.rs
+++ b/rust/kernel/chrdev.rs
@@ -181,6 +181,7 @@ impl<const N: usize> Registration<{ N }> {
         Ok(())
     }
 
+    /// The device number of last registered device
     pub fn last_registered_devt(self: Pin<&mut Self>) -> Option<u32>{
         let this = unsafe { self.get_unchecked_mut() };
         this.inner.as_mut().map(|inner|{

--- a/rust/kernel/chrdev.rs
+++ b/rust/kernel/chrdev.rs
@@ -180,6 +180,13 @@ impl<const N: usize> Registration<{ N }> {
         inner.used += 1;
         Ok(())
     }
+
+    pub fn last_registered_devt(self: Pin<&mut Self>) -> Option<u32>{
+        let this = unsafe { self.get_unchecked_mut() };
+        this.inner.as_mut().map(|inner|{
+            (inner.dev as u32 + (inner.used as u32 - 1)) as u32
+        })
+    }
 }
 
 // FIXME: update the kernel-doc comment once the API is finalised as below.

--- a/rust/kernel/chrdev.rs
+++ b/rust/kernel/chrdev.rs
@@ -183,6 +183,7 @@ impl<const N: usize> Registration<{ N }> {
 
     /// The device number of last registered device
     pub fn last_registered_devt(self: Pin<&mut Self>) -> Option<u32>{
+        // SAFETY: We must ensure that we never move out of `this`.
         let this = unsafe { self.get_unchecked_mut() };
         this.inner.as_mut().map(|inner|{
             (inner.dev as u32 + (inner.used as u32 - 1)) as u32

--- a/rust/kernel/class.rs
+++ b/rust/kernel/class.rs
@@ -49,10 +49,12 @@ impl Class {
         Ok(Self { ptr })
     }
 
+    /// Add the devnode call back function to the class.
     pub fn set_devnode<T: device::ClassDevnode>(&mut self) {
         unsafe { (*(self.ptr)).devnode = device::ClassDevnodeVtable::<T>::get_class_devnode_callback(); }
     }
 
+    /// The `get_ptr` method returns the raw pointer to the underlying `bindings::class` struct.
     pub fn get_ptr(&self) -> *mut bindings::class {
         self.ptr
     }

--- a/rust/kernel/class.rs
+++ b/rust/kernel/class.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0
 
-//! cpumask
+//! class
 //!
 //! C header: [`include/linux/device/class.h`](../../../../include/linux/device/class.h)
 
 use core::u32;
 
-use crate::{bindings, c_types, error::Error, Result};
+use crate::{bindings, c_types, error::Error, Result, device};
 
 extern "C" {
     #[allow(improper_ctypes)]
@@ -49,9 +49,13 @@ impl Class {
         Ok(Self { ptr })
     }
 
-    // fn add_function_devnode(){
+    pub fn set_devnode<T: device::ClassDevnode>(&mut self) {
+        unsafe { (*(self.ptr)).devnode = device::ClassDevnodeVtable::<T>::get_class_devnode_callback(); }
+    }
 
-    // }
+    pub fn get_ptr(&self) -> *mut bindings::class {
+        self.ptr
+    }
 }
 
 /// The `class_create` function is a helper function that creates a new device class. It takes a reference to the current module and a name, and returns a raw pointer to the created class./// The `DevT` struct is a wrapper around the `bindings::dev_t` struct from the kernel bindings. It represents a device type.

--- a/rust/kernel/device.rs
+++ b/rust/kernel/device.rs
@@ -1,17 +1,35 @@
 // SPDX-License-Identifier: GPL-2.0
 
-//! cpumask
+//! device
 //!
 //! C header: [`include/linux/device.h`](../../../../include/linux/device.h)
 
-use crate::{bindings, c_types};
+use crate::{
+    bindings, c_types,
+    str::CStr,
+    uidgid::{KgidT, KuidT},
+};
+
+use core::{marker::PhantomData, mem::ManuallyDrop};
+
 /// The `DeviceType` struct is a wrapper around the `bindings::device_type` struct from the kernel bindings. It represents a device type in the kernel.
+#[repr(transparent)]
 pub struct DeviceType(bindings::device_type);
 
 impl DeviceType {
-    /// The `new` method is a constructor for `DeviceType`. It creates a new `DeviceType` with a default `bindings::device_type`.
-    pub fn new() -> Self {
-        Self(bindings::device_type::default())
+    pub const fn new() -> Self {
+        Self(bindings::device_type{
+            name : core::ptr::null(),
+            groups : core::ptr::null_mut(),
+            uevent : None ,
+            devnode : None,
+            release : None,
+            pm : core::ptr::null()
+        })
+    }
+
+    pub fn get_name(&self) -> *const c_types::c_char {
+        self.0.name
     }
 
     /// The `name` method sets the name of the device type. It takes a pointer to a C-style string and sets the `name` field of the underlying `bindings::device_type` to that string.
@@ -20,21 +38,137 @@ impl DeviceType {
         self
     }
 
-    /// The `devnode` method sets the `devnode` function pointer of the device type. It takes an optional function pointer that is called to get the devnode of the device. If the function pointer is `None`, it sets the `devnode` field of the underlying `bindings::device_type` to null.
-    pub fn devnode(
-        &mut self,
-        devnode: Option<
-            unsafe extern "C" fn(
-                dev: *mut bindings::device,
-                mode: *mut bindings::umode_t,
-                uid: *mut bindings::kuid_t,
-                gid: *mut bindings::kgid_t,
-            ) -> *mut c_types::c_char,
-        >,
-    ) {
-        (self.0).devnode = devnode;
+    pub fn set_devnode<T: Devnode>(&mut self) {
+        unsafe {
+            self.0.devnode = DevnodeVtable::<T>::get_devnode_callback();
+        }
+    }
+
+    pub fn get_ptr(&self) -> *const bindings::device_type {
+        &self.0
     }
 }
 
 /// The `Device` struct is a wrapper around the `bindings::device` struct from the kernel bindings. It represents a device in the kernel.
-pub struct Device(bindings::device);
+pub struct Device(*mut bindings::device);
+
+impl Device {
+    // FIXME: temporarily used
+    pub unsafe fn raw_new<func>(mut init: func, name: &CStr) -> Self
+    where
+        func: FnMut(&mut bindings::device),
+    {
+        let dev = Box::try_new(bindings::device::default()).unwrap();
+        let dev = Box::leak(dev);
+        init(dev);
+        unsafe{bindings::dev_set_name(dev, name.as_char_ptr())};
+        unsafe{bindings::device_register(dev)};
+        Self(dev as *mut bindings::device)
+    }
+
+    #[inline]
+    pub fn dev_name(&self) -> *const c_types::c_char {
+        extern "C" {
+            fn rust_helper_dev_name(dev: *const bindings::device) -> *const c_types::c_char;
+        }
+        unsafe { rust_helper_dev_name(self.0 as *mut bindings::device as *const bindings::device) }
+    }
+
+    #[inline]
+    pub fn get_drvdata<T>(&mut self) -> Option<&T> {
+        let ptr = unsafe { (*self.0) }.driver_data as *const T;
+        if ptr.is_null() {
+            None
+        } else {
+            Some(unsafe { &*ptr })
+        }
+    }
+
+    #[inline]
+    pub fn set_drvdata<T>(&mut self, data: *mut T) {
+        // TODO: make sure data is pinned or belonged to dev
+        unsafe {
+            (*self.0).driver_data = data as *const T as *mut c_types::c_void;
+        }
+    }
+
+    #[inline]
+    pub fn dev_type(&self) -> Option<&DeviceType> {
+        unsafe {
+            if (*self.0).type_.is_null() {
+                None
+            } else {
+                Some(&*((*self.0).type_ as *const bindings::device_type as *const DeviceType))
+            }
+        }
+    }
+}
+
+pub trait ClassDevnode {
+    fn devnode(
+        dev: &mut Device,
+        mode: &mut u16,
+    ) -> *mut c_types::c_char;
+}
+
+pub trait Devnode {
+    fn devnode(
+        dev: &mut Device,
+        mode: &mut u16,
+        uid: Option<&mut KuidT>,
+        gid: Option<&mut KgidT>,
+    ) -> *mut c_types::c_char;
+}
+
+pub(crate) struct ClassDevnodeVtable<T: ClassDevnode>(PhantomData<T>);
+
+impl<T: ClassDevnode> ClassDevnodeVtable<T> {
+    pub(crate) unsafe fn get_class_devnode_callback() -> Option<
+        unsafe extern "C" fn(dev: *mut bindings::device, mode: *mut u16) -> *mut c_types::c_char,
+    > {
+        Some(class_devnode_callback::<T>)
+    }
+}
+pub(crate) struct DevnodeVtable<T: Devnode>(PhantomData<T>);
+impl<T: Devnode> DevnodeVtable<T> {
+    pub(crate) unsafe fn get_devnode_callback() -> Option<
+        unsafe extern "C" fn(
+            dev: *mut bindings::device,
+            mode: *mut u16,
+            uid: *mut bindings::kuid_t,
+            gid: *mut bindings::kgid_t,
+        ) -> *mut c_types::c_char,
+    > {
+        Some(devnode_callback::<T>)
+    }
+}
+
+unsafe extern "C" fn class_devnode_callback<T: ClassDevnode>(
+    dev: *mut bindings::device,
+    mode: *mut u16,
+) -> *mut c_types::c_char {
+    let dev = &mut Device(dev);
+    let mode = unsafe{&mut *mode};
+    T::devnode(dev, mode)
+}
+
+unsafe extern "C" fn devnode_callback<T: Devnode>(
+    dev: *mut bindings::device,
+    mode: *mut u16,
+    uid: *mut bindings::kuid_t,
+    gid: *mut bindings::kgid_t,
+) -> *mut c_types::c_char {
+    let dev = &mut Device(dev);
+    let mode = unsafe{&mut *mode};
+    let uid = if uid.is_null() {
+        None
+    } else {
+        unsafe{Some(&mut *(uid as *mut KuidT))}
+    };
+    let gid = if gid.is_null() {
+        None
+    } else {
+        unsafe{Some(&mut *(gid as *mut KgidT))}
+    };
+    T::devnode(dev, mode, uid, gid)
+}

--- a/rust/kernel/device.rs
+++ b/rust/kernel/device.rs
@@ -19,6 +19,7 @@ use core::marker::PhantomData;
 pub struct DeviceType(bindings::device_type);
 
 impl DeviceType {
+    /// create a raw new device_type
     pub const fn new() -> Self {
         Self(bindings::device_type {
             name: core::ptr::null(),
@@ -30,22 +31,25 @@ impl DeviceType {
         })
     }
 
+    /// get the name of the device type
     pub fn get_name(&self) -> *const c_types::c_char {
         self.0.name
     }
 
-    /// The `name` method sets the name of the device type. It takes a pointer to a C-style string and sets the `name` field of the underlying `bindings::device_type` to that string.
+    /// sets the name of the device type. It takes a pointer to a C-style string and sets the `name` field of the underlying `bindings::device_type` to that string.
     pub fn name(mut self, name: *const c_types::c_char) -> Self {
         (self.0).name = name;
         self
     }
 
+    /// set the devnode call back function to the device type
     pub fn set_devnode<T: Devnode>(&mut self) {
         unsafe {
             self.0.devnode = DevnodeVtable::<T>::get_devnode_callback();
         }
     }
 
+    /// returns the raw pointer to the underlying `bindings::device_type` struct.
     pub fn get_ptr(&self) -> *const bindings::device_type {
         &self.0
     }
@@ -55,6 +59,7 @@ impl DeviceType {
 pub struct Device(*mut bindings::device);
 
 impl Device {
+    /// create a raw new device, only used in factory currently
     // FIXME: temporarily used
     pub unsafe fn raw_new<FUNC>(mut init: FUNC, name: &CStr) -> Self
     where
@@ -68,6 +73,7 @@ impl Device {
         Self(dev as *mut bindings::device)
     }
 
+    /// set the name of the device
     #[inline]
     pub fn dev_name(&self) -> *const c_types::c_char {
         extern "C" {
@@ -76,6 +82,7 @@ impl Device {
         unsafe { rust_helper_dev_name(self.0 as *mut bindings::device as *const bindings::device) }
     }
 
+    /// get the driver data of the device
     #[inline]
     pub fn get_drvdata<T>(&mut self) -> Option<&T> {
         let ptr = unsafe { *self.0 }.driver_data as *const T;
@@ -86,6 +93,7 @@ impl Device {
         }
     }
 
+    /// set the driver data of the device
     #[inline]
     pub fn set_drvdata<T>(&mut self, data: *mut T) {
         // TODO: make sure data is pinned or belonged to dev
@@ -94,6 +102,7 @@ impl Device {
         }
     }
 
+    /// get the device type of the device
     #[inline]
     pub fn dev_type(&self) -> Option<&DeviceType> {
         unsafe {
@@ -106,11 +115,15 @@ impl Device {
     }
 }
 
+/// Class dev_node call back wrapper
 pub trait ClassDevnode {
+    /// dev_node call back function
     fn devnode(dev: &mut Device, mode: &mut u16) -> *mut c_types::c_char;
 }
 
+/// dev_node call back wrapper
 pub trait Devnode {
+    /// dev_node call back function
     fn devnode(
         dev: &mut Device,
         mode: &mut u16,

--- a/rust/kernel/device.rs
+++ b/rust/kernel/device.rs
@@ -44,6 +44,7 @@ impl DeviceType {
 
     /// set the devnode call back function to the device type
     pub fn set_devnode<T: Devnode>(&mut self) {
+        /// SAFETY: T that implement Devnode will certainly return a valid static function pointer
         unsafe {
             self.0.devnode = DevnodeVtable::<T>::get_devnode_callback();
         }
@@ -68,7 +69,9 @@ impl Device {
         let dev = Box::try_new(bindings::device::default()).unwrap();
         let dev = Box::leak(dev);
         init(dev);
+        /// SAFETY: the dev is valid, and the name will be copyed, so it don't have to be 'static
         unsafe { bindings::dev_set_name(dev, name.as_char_ptr()) };
+        /// SAFETY: the dev is valid
         unsafe { bindings::device_register(dev) };
         Self(dev as *mut bindings::device)
     }
@@ -85,6 +88,7 @@ impl Device {
     /// get the driver data of the device
     #[inline]
     pub fn get_drvdata<T>(&mut self) -> Option<&T> {
+        /// SAFETY: must ensure self.0 is valid
         let ptr = unsafe { *self.0 }.driver_data as *const T;
         if ptr.is_null() {
             None
@@ -97,6 +101,7 @@ impl Device {
     #[inline]
     pub fn set_drvdata<T>(&mut self, data: *mut T) {
         // TODO: make sure data is pinned or belonged to dev
+        /// SAFETY: must ensure self.0 is valid
         unsafe {
             (*self.0).driver_data = data as *const T as *mut c_types::c_void;
         }
@@ -105,6 +110,7 @@ impl Device {
     /// get the device type of the device
     #[inline]
     pub fn dev_type(&self) -> Option<&DeviceType> {
+        /// SAFETY: must ensure self.0 is valid
         unsafe {
             if (*self.0).type_.is_null() {
                 None

--- a/rust/kernel/file.rs
+++ b/rust/kernel/file.rs
@@ -142,3 +142,7 @@ impl Drop for FileDescriptorReservation {
         unsafe { bindings::put_unused_fd(self.fd) };
     }
 }
+
+pub fn fd_install(fd: u32, filp: *mut bindings::file) {
+    unsafe { bindings::fd_install(fd, filp); }
+}

--- a/rust/kernel/file.rs
+++ b/rust/kernel/file.rs
@@ -145,5 +145,6 @@ impl Drop for FileDescriptorReservation {
 
 /// call linux fd_install
 pub fn fd_install(fd: u32, filp: *mut bindings::file) {
+    /// SAFETY: The caller must ensure that `filp` is a valid pointer.
     unsafe { bindings::fd_install(fd, filp); }
 }

--- a/rust/kernel/file.rs
+++ b/rust/kernel/file.rs
@@ -143,6 +143,7 @@ impl Drop for FileDescriptorReservation {
     }
 }
 
+/// call linux fd_install
 pub fn fd_install(fd: u32, filp: *mut bindings::file) {
     unsafe { bindings::fd_install(fd, filp); }
 }

--- a/rust/kernel/kernelh.rs
+++ b/rust/kernel/kernelh.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0
+
+//! kernel
+//!
+//! C header: [`include/linux/kernel.h`](../../../../include/linux/kernel.h)
+
+use crate::{
+    bindings,
+    prelude::*,
+    Result,
+    c_types::*,
+};
+
+// FIXME: how to wrapper `...` in parameters
+#[inline]
+pub fn _kasprintf_1(gfp: bindings::gfp_t, fmt: *const c_char, arg1: *const c_char) -> *mut c_char {
+    unsafe { bindings::kasprintf(gfp, fmt, arg1) }
+}
+
+#[inline]
+pub fn _kasprintf_2(gfp: bindings::gfp_t, fmt: *const c_char, arg1: *const c_char,arg2: *const c_char) -> *mut c_char {
+    unsafe { bindings::kasprintf(gfp, fmt, arg1,arg2) }
+}
+
+// unused macro, refactor later
+#[macro_export]
+macro_rules! kasprintf {
+    ($gfp:expr,$fmt:expr, $arg1:expr) => {
+        use kernel::kernelh::_kasprintf_1;
+        unsafe {
+            _kasprintf_1($gfp, $fmt, $arg1)
+        }
+    };
+    ($gfp:expr,$fmt:expr, $arg1:expr,$arg2:expr) => {
+        use kernel::kernelh::_kasprintf_2;
+        unsafe {
+            _kasprintf_2($gfp, $fmt, $arg1,$arg2)
+        }
+    };
+}
+
+pub fn do_exit(error_code: c_long) {
+    unsafe { bindings::do_exit(error_code); }
+}

--- a/rust/kernel/kernelh.rs
+++ b/rust/kernel/kernelh.rs
@@ -6,39 +6,23 @@
 
 use crate::{
     bindings,
-    prelude::*,
-    Result,
     c_types::*,
 };
 
 // FIXME: how to wrapper `...` in parameters
+/// The `printk` function is a wrapper around the `printk` function from the kernel.
 #[inline]
 pub fn _kasprintf_1(gfp: bindings::gfp_t, fmt: *const c_char, arg1: *const c_char) -> *mut c_char {
     unsafe { bindings::kasprintf(gfp, fmt, arg1) }
 }
 
+/// The `printk` function is a wrapper around the `printk` function from the kernel.
 #[inline]
 pub fn _kasprintf_2(gfp: bindings::gfp_t, fmt: *const c_char, arg1: *const c_char,arg2: *const c_char) -> *mut c_char {
     unsafe { bindings::kasprintf(gfp, fmt, arg1,arg2) }
 }
 
-// unused macro, refactor later
-#[macro_export]
-macro_rules! kasprintf {
-    ($gfp:expr,$fmt:expr, $arg1:expr) => {
-        use kernel::kernelh::_kasprintf_1;
-        unsafe {
-            _kasprintf_1($gfp, $fmt, $arg1)
-        }
-    };
-    ($gfp:expr,$fmt:expr, $arg1:expr,$arg2:expr) => {
-        use kernel::kernelh::_kasprintf_2;
-        unsafe {
-            _kasprintf_2($gfp, $fmt, $arg1,$arg2)
-        }
-    };
-}
-
+/// call linux do_exit
 pub fn do_exit(error_code: c_long) {
     unsafe { bindings::do_exit(error_code); }
 }

--- a/rust/kernel/lib.rs
+++ b/rust/kernel/lib.rs
@@ -21,6 +21,7 @@
     const_panic,
     const_raw_ptr_deref,
     const_unreachable_unchecked,
+    const_fn_fn_ptr_basics,
     receiver_trait,
     try_reserve,
     unsafe_cell_raw_get
@@ -104,6 +105,7 @@ pub mod uapi;
 pub mod uidgid;
 pub mod vmalloc;
 pub mod workqueue;
+pub mod kernelh;
 
 #[doc(hidden)]
 pub use build_error::build_error;

--- a/rust/kernel/uidgid.rs
+++ b/rust/kernel/uidgid.rs
@@ -11,27 +11,35 @@ use crate::bindings::{self};
 /// It includes a public field which is an instance of `kuid_t`.
 #[derive(Copy, Clone)]
 pub struct KuidT(pub bindings::kuid_t);
+
+/// Struct `KgidT` represents a kernel group ID.
+/// It wraps the `kgid_t` struct from the bindings module.
+/// It includes a public field which is an instance of `kgid_t`.
 #[derive(Copy, Clone)]
 pub struct KgidT(pub bindings::kgid_t);
 
 impl KuidT {
+    /// Takes a pointer to a `u8` and returns a `KuidT` struct.
     pub fn from_ptr(ptr: *const u8) -> Self {
         unsafe { Self((*(ptr as *const bindings::inode)).i_uid) }
     }
 
+    /// Returns a `KuidT` struct with the value of 0.
+    /// Corresponds to the C macro GLOBAL_ROOT_UID.
     pub fn global_root_uid() -> Self {
         Self(bindings::kuid_t { val: 0 })
     }
 }
 
-/// Struct `KgidT` represents a kernel group ID.
-/// It wraps the `kgid_t` struct from the bindings module.
-/// It includes a public field which is an instance of `kgid_t`.
+
 impl KgidT {
+    /// Takes a pointer to a `u8` and returns a `KgidT` struct.
     pub fn from_ptr(ptr: *const u8) -> Self {
         unsafe { Self((*(ptr as *const bindings::inode)).i_gid) }
     }
 
+    /// Returns a `KgidT` struct with the value of 0.
+    /// Corresponds to the C macro GLOBAL_ROOT_GID.
     pub fn global_root_gid() -> Self {
         Self(bindings::kgid_t { val: 0 })
     }

--- a/rust/kernel/uidgid.rs
+++ b/rust/kernel/uidgid.rs
@@ -19,11 +19,6 @@ pub struct KuidT(pub bindings::kuid_t);
 pub struct KgidT(pub bindings::kgid_t);
 
 impl KuidT {
-    /// Takes a pointer to a `u8` and returns a `KuidT` struct.
-    pub fn from_ptr(ptr: *const u8) -> Self {
-        unsafe { Self((*(ptr as *const bindings::inode)).i_uid) }
-    }
-
     /// Returns a `KuidT` struct with the value of 0.
     /// Corresponds to the C macro GLOBAL_ROOT_UID.
     pub fn global_root_uid() -> Self {
@@ -33,11 +28,6 @@ impl KuidT {
 
 
 impl KgidT {
-    /// Takes a pointer to a `u8` and returns a `KgidT` struct.
-    pub fn from_ptr(ptr: *const u8) -> Self {
-        unsafe { Self((*(ptr as *const bindings::inode)).i_gid) }
-    }
-
     /// Returns a `KgidT` struct with the value of 0.
     /// Corresponds to the C macro GLOBAL_ROOT_GID.
     pub fn global_root_gid() -> Self {

--- a/rust/kernel/uidgid.rs
+++ b/rust/kernel/uidgid.rs
@@ -1,17 +1,38 @@
 // SPDX-License-Identifier: GPL-2.0
 
-//! cpumask
+//! uidgid
 //!
 //! C header: [`include/linux/uidgid.h`](../../../../include/linux/uidgid.h)
 
-use crate::bindings;
+use crate::bindings::{self};
 
 /// Struct `KuidT` represents a kernel user ID.
 /// It wraps the `kuid_t` struct from the bindings module.
 /// It includes a public field which is an instance of `kuid_t`.
+#[derive(Copy, Clone)]
 pub struct KuidT(pub bindings::kuid_t);
+#[derive(Copy, Clone)]
+pub struct KgidT(pub bindings::kgid_t);
+
+impl KuidT {
+    pub fn from_ptr(ptr: *const u8) -> Self {
+        unsafe { Self((*(ptr as *const bindings::inode)).i_uid) }
+    }
+
+    pub fn global_root_uid() -> Self {
+        Self(bindings::kuid_t { val: 0 })
+    }
+}
 
 /// Struct `KgidT` represents a kernel group ID.
 /// It wraps the `kgid_t` struct from the bindings module.
 /// It includes a public field which is an instance of `kgid_t`.
-pub struct KgidT(pub bindings::kgid_t);
+impl KgidT {
+    pub fn from_ptr(ptr: *const u8) -> Self {
+        unsafe { Self((*(ptr as *const bindings::inode)).i_gid) }
+    }
+
+    pub fn global_root_gid() -> Self {
+        Self(bindings::kgid_t { val: 0 })
+    }
+}


### PR DESCRIPTION
I have filled the missing callback function of `devnode` and add the function `create_sys_device` to trigger the process of creating devices.
