### PR TITLE
rust: control factory: Fix bug about `rust_helper_pa`.

### DIFF
--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -1139,7 +1139,7 @@ void* rust_helper_kthread_run_on_cpu(int (*threadfn)(void *data), void *data, in
 }
 EXPORT_SYMBOL_GPL(rust_helper_kthread_run_on_cpu);
 
-int rust_helper_pa(unsigned long x) {
+unsigned long rust_helper_pa(unsigned long x) {
 	return __virt_to_phys(x);
 }
 EXPORT_SYMBOL_GPL(rust_helper_pa);

--- a/rust/kernel/mm.rs
+++ b/rust/kernel/mm.rs
@@ -71,5 +71,6 @@ type PgprotT = bindings::pgprot_t;
 
 /// This constant is used to set the protection attributes of a page to shared.
 pub const PAGE_SHARED: PgprotT = PgprotT {
-    pgprot: 4035 as u64,
+    // HACK: temporary hack for pgprot_t
+    pgprot: 0x68000000000fc3 as u64,
 };


### PR DESCRIPTION
- The `PAGE_SHARED` setting error caused the memory of mmap to be unwritable. I temporarily modified it in a HACK way, but I consider that this part could be implemented by Rust-For-Linux.
 - The `rust_helper_pa` function calls the `__virt_to_phys macro` in C code. The type of this macro is phys_addr_t (typedef u64 phys_addr_t). The return type is int, which leads to truncation of the return value, so I changed it to unsigned long.
    
https://github.com/BUPT-OS/RROS/issues/12