### PR TITLE
rust: trace: add trace subsystem support

### DIFF
--- a/include/trace/events/rros.h
+++ b/include/trace/events/rros.h
@@ -1,0 +1,837 @@
+#undef TRACE_SYSTEM
+#define TRACE_SYSTEM rros
+
+#if !defined(_TRACE_RROS_H) || defined(TRACE_HEADER_MULTI_READ)
+#define _TRACE_RROS_H
+
+#include <linux/tracepoint.h>
+#include <linux/trace_seq.h>
+
+DECLARE_EVENT_CLASS(thread_event,
+	TP_PROTO(pid_t pid,u32 state,u32 info),
+	TP_ARGS(pid,state,info),
+
+	TP_STRUCT__entry(
+		__field(pid_t, pid)
+		__field(u32, state)
+		__field(u32, info)
+	),
+
+	TP_fast_assign(
+		__entry->pid = pid;
+		__entry->state = state;
+		__entry->info = info;
+	),
+
+	TP_printk("pid=%d state=%#x info=%#x",
+		  __entry->pid, __entry->state, __entry->info)
+);
+
+DECLARE_EVENT_CLASS(curr_thread_event,
+	TP_PROTO(u32 state,u32 info),
+	TP_ARGS(state,info),
+
+	TP_STRUCT__entry(
+		__field(u32, state)
+		__field(u32, info)
+	),
+
+	TP_fast_assign(
+		__entry->state = state;
+		__entry->info = info;
+	),
+
+	TP_printk("state=%#x info=%#x",
+		  __entry->state, __entry->info)
+);
+
+DECLARE_EVENT_CLASS(wq_event,
+	TP_PROTO(const char *name),
+	TP_ARGS(name),
+
+	TP_STRUCT__entry(
+		__string(name, name)
+	),
+
+	TP_fast_assign(
+        __assign_str(name, name);
+    ),
+
+	TP_printk("wq=%s", __get_str(name))
+);
+
+DECLARE_EVENT_CLASS(timer_event,
+	TP_PROTO(const char *name),
+	TP_ARGS(name),
+
+	TP_STRUCT__entry(
+		__string(name, name)
+	),
+
+	TP_fast_assign(
+        __assign_str(name, name);
+    ),
+
+	TP_printk("timer=%s", __get_str(name))
+);
+
+#define rros_print_syscall(__nr)			\
+	__print_symbolic(__nr,			\
+			 { 0, "oob_read"  },	\
+			 { 1, "oob_write" },	\
+			 { 2, "oob_ioctl" })
+
+DECLARE_EVENT_CLASS(rros_syscall_entry,
+	TP_PROTO(unsigned int nr),
+	TP_ARGS(nr),
+
+	TP_STRUCT__entry(
+		__field(unsigned int, nr)
+	),
+
+	TP_fast_assign(
+		__entry->nr = nr;
+	),
+
+	TP_printk("syscall=%s", rros_print_syscall(__entry->nr))
+);
+
+DECLARE_EVENT_CLASS(rros_syscall_exit,
+	TP_PROTO(long result),
+	TP_ARGS(result),
+
+	TP_STRUCT__entry(
+		__field(long, result)
+	),
+
+	TP_fast_assign(
+		__entry->result = result;
+	),
+
+	TP_printk("result=%ld", __entry->result)
+);
+
+// #define rros_print_sched_policy(__policy)		\
+// 	__print_symbolic(__policy,			\
+// 			 {0, "normal"},	\
+// 			 {1, "fifo"},		\
+// 			 {2, "rr"},		\
+// 			 {44, "quota"},	\ //FIXME: export symbol
+// 			 {43, "weak"})
+
+// const char *rros_trace_sched_attrs(struct trace_seq *seq,
+// 				  struct rros_sched_attrs *attrs);
+
+// DECLARE_EVENT_CLASS(rros_sched_attrs,
+// 	TP_PROTO(void *thread,
+// 		 const struct rros_sched_attrs *attrs),
+// 	TP_ARGS(thread, attrs),
+
+// 	TP_STRUCT__entry(
+// 		__field(void *, thread)
+// 		__field(int, policy)
+// 		__dynamic_array(char, attrs, sizeof(struct rros_sched_attrs))
+// 	),
+
+// 	TP_fast_assign(
+// 		__entry->thread = thread;
+// 		__entry->policy = attrs->sched_policy;
+// 		memcpy(__get_dynamic_array(attrs), attrs, sizeof(*attrs));
+// 	),
+
+// 	TP_printk("thread=%s policy=%s param={ %s }",
+// 		  rros_element_name(&__entry->thread->element)?
+// 		  rros_element_name(&__entry->thread->element):"{ }",
+// 		  rros_print_sched_policy(__entry->policy),
+// 		  rros_trace_sched_attrs(p,
+// 					(struct rros_sched_attrs *)
+// 					__get_dynamic_array(attrs))
+// 	)
+// );
+
+DECLARE_EVENT_CLASS(rros_clock_timespec,
+	TP_PROTO(const char *name, const struct timespec64 *val),
+	TP_ARGS(name, val),
+
+	TP_STRUCT__entry(
+		__field(time64_t, tv_sec_val)	
+		__field(long long, tv_nsec_val)
+		__string(name, name)
+	),
+
+	TP_fast_assign(
+		__entry->tv_sec_val = val->tv_sec;
+		__entry->tv_nsec_val = val->tv_nsec;
+		__assign_str(name, name);
+	),
+
+	TP_printk("clock=%s timeval=(%lld.%09lld)",
+		  __get_str(name),
+		  __entry->tv_sec_val,__entry->tv_nsec_val
+	)
+);
+
+DECLARE_EVENT_CLASS(rros_clock_ident,
+	TP_PROTO(const char *name),
+	TP_ARGS(name),
+	TP_STRUCT__entry(
+		__string(name, name)
+	),
+	TP_fast_assign(
+		__assign_str(name, name);
+	),
+	TP_printk("name=%s", __get_str(name))
+);
+
+DECLARE_EVENT_CLASS(rros_schedule_event,
+	TP_PROTO(unsigned long flags,unsigned long local_flags),
+	TP_ARGS(flags,local_flags),
+
+	TP_STRUCT__entry(
+		__field(unsigned long, flags)
+		__field(unsigned long, local_flags)
+	),
+
+	TP_fast_assign(
+		__entry->flags = flags;
+		__entry->local_flags = local_flags;
+	),
+
+	TP_printk("flags=%#lx, local_flags=%#lx",
+		  __entry->flags, __entry->local_flags)
+);
+
+DEFINE_EVENT(rros_schedule_event, rros_schedule,
+	TP_PROTO(unsigned long flags,unsigned long local_flags),
+	TP_ARGS(flags,local_flags)
+);
+
+DEFINE_EVENT(rros_schedule_event, rros_reschedule_ipi,
+	TP_PROTO(unsigned long flags,unsigned long local_flags),
+	TP_ARGS(flags,local_flags)
+);
+
+TRACE_EVENT(rros_pick_thread,
+	TP_PROTO(const char* name,pid_t next_pid),
+	TP_ARGS(name,next_pid),
+
+	TP_STRUCT__entry(
+		__string(name, name)
+		__field(pid_t, next_pid)
+	),
+
+	TP_fast_assign(
+		__assign_str(name, name);
+		__entry->next_pid = next_pid;
+	),
+
+	TP_printk("{ next=%s[%d] }",
+		__get_str(name), __entry->next_pid)
+);
+
+TRACE_EVENT(rros_switch_context,
+	TP_PROTO(const char *prev_name,const char *next_name,pid_t prev_pid,int prev_prio,u32 prev_state,pid_t next_pid,int next_prio),
+	TP_ARGS(prev_name, next_name,prev_pid,prev_prio,prev_state,next_pid,next_prio),
+
+	TP_STRUCT__entry(
+		__string(prev_name, prev_name)
+		__string(next_name, next_name)
+		__field(pid_t, prev_pid)
+		__field(int, prev_prio)
+		__field(u32, prev_state)
+		__field(pid_t, next_pid)
+		__field(int, next_prio)
+	),
+
+	TP_fast_assign(
+		__entry->prev_pid = prev_pid;
+		__entry->prev_prio = prev_prio;
+		__entry->prev_state = prev_state;
+		__entry->next_pid = next_pid;
+		__entry->next_prio = next_prio;
+		__assign_str(prev_name, prev_name);
+		__assign_str(next_name, next_name);
+	),
+
+	TP_printk("{ %s[%d] prio=%d, state=%#x } => { %s[%d] prio=%d }",
+		  __get_str(prev_name), __entry->prev_pid,
+		  __entry->prev_prio, __entry->prev_state,
+		  __get_str(next_name), __entry->next_pid, __entry->next_prio)
+);
+
+TRACE_EVENT(rros_switch_tail,
+	TP_PROTO(const char* curr_name,pid_t curr_pid),
+	TP_ARGS(curr_name,curr_pid),
+
+	TP_STRUCT__entry(
+		__string(curr_name, curr_name)
+		__field(pid_t, curr_pid)
+	),
+
+	TP_fast_assign(
+		__assign_str(curr_name, curr_name);
+		__entry->curr_pid = curr_pid;
+	),
+
+	TP_printk("{ current=%s[%d] }",
+		__get_str(curr_name), __entry->curr_pid)
+);
+
+TRACE_EVENT(rros_init_thread,
+	TP_PROTO(void* thread,const char* thread_name,const char *class_name,
+		unsigned long flags, int cprio,int status),
+	TP_ARGS(thread,thread_name,class_name, flags,cprio,status),
+
+	TP_STRUCT__entry(
+		__field(void *, thread)
+		__string(thread_name, thread_name)
+		__string(class_name, class_name)
+		__field(unsigned long, flags)
+		__field(int, cprio)
+		__field(int, status)
+	),
+
+	TP_fast_assign(
+		__entry->thread = thread;
+		__assign_str(thread_name, thread_name);
+		// __entry->flags = iattr->flags | (iattr->observable ? T_OBSERV : 0); //TODO:
+		__entry->flags = flags;
+		__assign_str(class_name, class_name);
+		__entry->cprio = cprio;
+		__entry->status = status;
+	),
+
+	TP_printk("thread=%p name=%s flags=%#lx class=%s prio=%d status=%#x",
+		   __entry->thread, __get_str(thread_name), __entry->flags,
+		  __get_str(class_name), __entry->cprio, __entry->status)
+);
+
+TRACE_EVENT(rros_sleep_on,
+	TP_PROTO(pid_t pid,ktime_t timeout,
+		 int timeout_mode, void *wchan,const char* clock_name,
+		 const char* wchan_name),
+	TP_ARGS(pid,timeout, timeout_mode, wchan,clock_name,wchan_name),
+
+	TP_STRUCT__entry(
+		__field(pid_t, pid)
+		__field(ktime_t, timeout)
+		__field(int, timeout_mode)
+		__field(void *, wchan)
+		__string(wchan_name, wchan_name)
+		__string(clock_name, clock_name)
+	),
+
+	TP_fast_assign(
+		__entry->pid = pid;
+		__entry->timeout = timeout;
+		__entry->timeout_mode = timeout_mode;
+		__entry->wchan = wchan;
+		__assign_str(clock_name, clock_name);
+		__assign_str(wchan_name, wchan_name);
+	),
+
+	TP_printk("pid=%d timeout=%Lu timeout_mode=%d clock=%s wchan=%s(%p)",
+		  __entry->pid,
+		  ktime_to_ns(__entry->timeout), __entry->timeout_mode,
+		  __get_str(clock_name),
+		  __get_str(wchan_name),
+		  __entry->wchan)
+);
+
+TRACE_EVENT(rros_wakeup_thread,
+	TP_PROTO(const char *thread_name,pid_t pid, int mask, int info),
+	TP_ARGS(thread_name,pid, mask, info),
+
+	TP_STRUCT__entry(
+		__string(name, thread_name)
+		__field(pid_t, pid)
+		__field(int, mask)
+		__field(int, info)
+	),
+
+	TP_fast_assign(
+		__assign_str(name, thread_name);
+		__entry->pid = pid;
+		__entry->mask = mask;
+		__entry->info = info;
+	),
+
+	TP_printk("name=%s pid=%d mask=%#x info=%#x",
+		__get_str(name), __entry->pid,
+		__entry->mask, __entry->info)
+);
+
+TRACE_EVENT(rros_hold_thread,
+	TP_PROTO(const char *thread_name,pid_t pid, unsigned long mask),
+	TP_ARGS(thread_name, pid, mask),
+
+	TP_STRUCT__entry(
+		__string(thread_name, thread_name)
+		__field(pid_t, pid)
+		__field(unsigned long, mask)
+	),
+
+	TP_fast_assign(
+		__assign_str(thread_name, thread_name);
+		__entry->pid = pid;
+		__entry->mask = mask;
+	),
+
+	TP_printk("name=%s pid=%d mask=%#lx",
+		  __get_str(thread_name), __entry->pid, __entry->mask)
+);
+
+TRACE_EVENT(rros_release_thread,
+	TP_PROTO(const char *thread_name,pid_t pid, int mask, int info),
+	TP_ARGS(thread_name, pid, mask, info),
+
+	TP_STRUCT__entry(
+		__string(thread_name, thread_name)
+		__field(pid_t, pid)
+		__field(int, mask)
+		__field(int, info)
+	),
+
+	TP_fast_assign(
+		__assign_str(thread_name, thread_name);
+		__entry->pid = pid;
+		__entry->mask = mask;
+		__entry->info = info;
+	),
+
+	TP_printk("name=%s pid=%d mask=%#x info=%#x",
+		__get_str(thread_name), __entry->pid,
+		__entry->mask, __entry->info)
+);
+
+// TRACE_EVENT(rros_thread_fault,
+// 	TP_PROTO(int trapnr, struct pt_regs *regs),
+// 	TP_ARGS(trapnr, regs),
+
+// 	TP_STRUCT__entry(
+// 		__field(long,	ip)
+// 		__field(unsigned int, trapnr)
+// 	),
+
+// 	TP_fast_assign(
+// 		__entry->ip = instruction_pointer(regs);
+// 		__entry->trapnr = trapnr;
+// 	),
+
+// 	TP_printk("ip=%#lx trapnr=%#x",
+// 		  __entry->ip, __entry->trapnr)
+// );
+
+TRACE_EVENT(rros_thread_set_current_prio,
+	TP_PROTO(void *thread,pid_t pid, int cprio),
+	TP_ARGS(thread,pid,cprio),
+
+	TP_STRUCT__entry(
+		__field(void *, thread)
+		__field(pid_t, pid)
+		__field(int, cprio)
+	),
+
+	TP_fast_assign(
+		__entry->thread = thread;
+		__entry->pid = pid;
+		__entry->cprio = cprio;
+	),
+
+	TP_printk("thread=%p pid=%d prio=%d",
+		  __entry->thread, __entry->pid, __entry->cprio)
+);
+
+DEFINE_EVENT(thread_event, rros_thread_cancel,
+	TP_PROTO(pid_t pid,u32 state,u32 info),
+	TP_ARGS(pid,state,info)
+);
+
+DEFINE_EVENT(thread_event, rros_thread_join,
+	TP_PROTO(int pid,u32 state,u32 info),
+	TP_ARGS(pid,state,info)
+);
+
+DEFINE_EVENT(thread_event, rros_unblock_thread,
+	TP_PROTO(int pid,u32 state,u32 info),
+	TP_ARGS(pid,state,info)
+);
+
+DEFINE_EVENT(curr_thread_event, rros_thread_wait_period,
+	TP_PROTO(u32 state,u32 info),
+	TP_ARGS(state,info)
+);
+
+DEFINE_EVENT(curr_thread_event, rros_thread_missed_period,
+	TP_PROTO(u32 state,u32 info),
+	TP_ARGS(state,info)
+);
+
+TRACE_EVENT(rros_thread_migrate,
+	TP_PROTO(void *thread,pid_t pid,unsigned int cpu),
+	TP_ARGS(thread,pid,cpu),
+
+	TP_STRUCT__entry(
+		__field(void *, thread)
+		__field(pid_t, pid)
+		__field(unsigned int, cpu)
+	),
+
+	TP_fast_assign(
+		__entry->thread = thread;
+		__entry->pid = pid;
+		__entry->cpu = cpu;
+	),
+
+	TP_printk("thread=%p pid=%d cpu=%u",
+		  __entry->thread, __entry->pid, __entry->cpu)
+);
+
+DEFINE_EVENT(curr_thread_event, rros_watchdog_signal,
+	TP_PROTO(u32 state,u32 info),
+	TP_ARGS(state,info)
+);
+
+DEFINE_EVENT(curr_thread_event, rros_switch_oob,
+	TP_PROTO(u32 state,u32 info),
+	TP_ARGS(state,info)
+);
+
+DEFINE_EVENT(curr_thread_event, rros_switched_oob,
+	TP_PROTO(u32 state,u32 info),
+	TP_ARGS(state,info)
+);
+
+#define rros_print_switch_cause(cause)						\
+	__print_symbolic(cause,							\
+			{ -1,		"breakpoint trap" },	\
+			{ 0,		"undefined" },		\
+			{ 1,		"in-band signal" }, 	\
+			{ 2,		"in-band syscall" },	\
+			{ 3,		"processor exception" },\
+			{ 4,		"watchdog" },		\
+			{ 5,		"lock dependency" },	\
+			{ 6,	"lock imbalance" },	\
+			{ 7,		"sleep holding lock" },	\
+			{ 8,		"stage exclusion" } )
+
+TRACE_EVENT(rros_switch_inband,
+	TP_PROTO(int cause),
+	TP_ARGS(cause),
+
+	TP_STRUCT__entry(
+		__field(int, cause)
+	),
+
+	TP_fast_assign(
+		__entry->cause = cause;
+	),
+
+	TP_printk("cause=%s", rros_print_switch_cause(__entry->cause))
+);
+
+DEFINE_EVENT(curr_thread_event, rros_switched_inband,
+	TP_PROTO(u32 state,u32 info),
+	TP_ARGS(state,info)
+);
+
+DEFINE_EVENT(curr_thread_event, rros_kthread_entry,
+	TP_PROTO(u32 state,u32 info),
+	TP_ARGS(state,info)
+);
+
+TRACE_EVENT(rros_thread_map,
+	TP_PROTO(void* thread,pid_t pid,int prio),
+	TP_ARGS(thread,pid,prio),
+
+	TP_STRUCT__entry(
+		__field(void *, thread)
+		__field(pid_t, pid)
+		__field(int, prio)
+	),
+
+	TP_fast_assign(
+		__entry->thread = thread;
+		__entry->pid = pid;
+		__entry->prio = prio;
+	),
+
+	TP_printk("thread=%p pid=%d prio=%d",
+		  __entry->thread, __entry->pid, __entry->prio)
+);
+
+DEFINE_EVENT(curr_thread_event, rros_thread_unmap,
+	TP_PROTO(u32 state,u32 info),
+	TP_ARGS(state,info)
+);
+
+TRACE_EVENT(rros_inband_wakeup,
+	TP_PROTO(pid_t pid,char* comm),
+	TP_ARGS(pid,comm),
+
+	TP_STRUCT__entry(
+		__field(pid_t, pid)
+		__array(char, comm, TASK_COMM_LEN)
+	),
+
+	TP_fast_assign(
+		__entry->pid = pid;
+		memcpy(__entry->comm, comm, TASK_COMM_LEN);
+	),
+
+	TP_printk("pid=%d comm=%s",
+		  __entry->pid, __entry->comm)
+);
+
+TRACE_EVENT(rros_inband_signal,
+	TP_PROTO(const char *element_name,pid_t pid, int sig, int sigval),
+	TP_ARGS(element_name,pid, sig, sigval),
+
+	TP_STRUCT__entry(
+		__string(element_name, element_name)
+		__field(pid_t, pid)
+		__field(int, sig)
+		__field(int, sigval)
+	),
+
+	TP_fast_assign(
+		__assign_str(element_name, element_name);
+		__entry->pid = pid;
+		__entry->sig = sig;
+		__entry->sigval = sigval;
+	),
+
+	/* Caller holds a reference on @thread, memory cannot be stale. */
+	TP_printk("thread=%s pid=%d sig=%d sigval=%d",
+		__get_str(element_name),
+		__entry->pid,
+		__entry->sig, __entry->sigval)
+);
+
+DEFINE_EVENT(timer_event, rros_timer_stop,
+	TP_PROTO(const char *name),
+	TP_ARGS(name)
+);
+
+DEFINE_EVENT(timer_event, rros_timer_expire,
+	TP_PROTO(const char *name),
+	TP_ARGS(name)
+);
+#define rros_print_timer_mode(mode)		\
+	__print_symbolic(mode,			\
+			 { 0, "rel" },	\
+			 { 1, "abs" })
+
+TRACE_EVENT(rros_timer_start,
+	TP_PROTO(const char *timer_name, ktime_t value, ktime_t interval),
+	TP_ARGS(timer_name, value, interval),
+
+	TP_STRUCT__entry(
+		__string(timer_name, timer_name)
+		__field(ktime_t, value)
+		__field(ktime_t, interval)
+	),
+
+	TP_fast_assign(
+		__assign_str(timer_name, timer_name);
+		__entry->value = value;
+		__entry->interval = interval;
+	),
+
+	TP_printk("timer=%s value=%Lu interval=%Lu",
+		__get_str(timer_name),
+		ktime_to_ns(__entry->value),
+		ktime_to_ns(__entry->interval))
+);
+
+TRACE_EVENT(rros_timer_move,
+	TP_PROTO(const char* timer_name,
+		 const char* clock_name,
+		 unsigned int cpu),
+	TP_ARGS(timer_name, clock_name, cpu),
+
+	TP_STRUCT__entry(
+		__field(unsigned int, cpu)
+		__string(timer_name, timer_name)
+		__string(clock_name, clock_name)
+	),
+
+	TP_fast_assign(
+		__entry->cpu = cpu;
+		__assign_str(timer_name, timer_name);
+		__assign_str(clock_name, clock_name);
+	),
+
+	TP_printk("timer=%s clock=%s cpu=%u",
+		  __get_str(timer_name),
+		  __get_str(clock_name),
+		  __entry->cpu)
+);
+
+TRACE_EVENT(rros_timer_shot,
+	TP_PROTO(const char* timer_name, s64 delta, u64 cycles),
+	TP_ARGS(timer_name, delta, cycles),
+
+	TP_STRUCT__entry(
+		__field(u64, secs)
+		__field(u32, nsecs)
+		__field(s64, delta)
+		__field(u64, cycles)
+		__string(name, timer_name)
+	),
+
+	TP_fast_assign(
+		__entry->cycles = cycles;
+		__entry->delta = delta;
+		__entry->secs = div_u64_rem(trace_clock_local() + delta,
+					    NSEC_PER_SEC, &__entry->nsecs);
+		__assign_str(name, timer_name);
+	),
+
+	TP_printk("%s at %Lu.%06u (delay: %Ld us, %Lu cycles)",
+		  __get_str(name),
+		  (unsigned long long)__entry->secs,
+		  __entry->nsecs / 1000, div_s64(__entry->delta, 1000),
+		  __entry->cycles)
+);
+
+DEFINE_EVENT(wq_event, rros_wait,
+	TP_PROTO(const char *name),
+	TP_ARGS(name)
+);
+
+DEFINE_EVENT(wq_event, rros_wake_up,
+	TP_PROTO(const char *name),
+	TP_ARGS(name)
+);
+
+DEFINE_EVENT(wq_event, rros_flush_wait,
+	TP_PROTO(const char *name),
+	TP_ARGS(name)
+);
+
+DEFINE_EVENT(wq_event, rros_finish_wait,
+	TP_PROTO(const char *name),
+	TP_ARGS(name)
+);
+
+DEFINE_EVENT(rros_syscall_entry, rros_oob_sysentry,
+	TP_PROTO(unsigned int nr),
+	TP_ARGS(nr)
+);
+
+DEFINE_EVENT(rros_syscall_exit, rros_oob_sysexit,
+	TP_PROTO(long result),
+	TP_ARGS(result)
+);
+
+DEFINE_EVENT(rros_syscall_entry, rros_inband_sysentry,
+	TP_PROTO(unsigned int nr),
+	TP_ARGS(nr)
+);
+
+DEFINE_EVENT(rros_syscall_exit, rros_inband_sysexit,
+	TP_PROTO(long result),
+	TP_ARGS(result)
+);
+
+// DEFINE_EVENT(rros_sched_attrs, rros_thread_setsched,
+// 	TP_PROTO(struct rros_thread *thread,
+// 		 const struct rros_sched_attrs *attrs),
+// 	TP_ARGS(thread, attrs)
+// );
+
+// DEFINE_EVENT(rros_sched_attrs, rros_thread_getsched,
+// 	TP_PROTO(struct rros_thread *thread,
+// 		 const struct rros_sched_attrs *attrs),
+// 	TP_ARGS(thread, attrs)
+// );
+
+#define rros_print_thread_mode(__mode)	\
+	__print_flags(__mode, "|",	\
+		{0x00200000, "hmobs"},	\
+		{0x00100000, "hmsig"},	\
+		{0x00020000, "wosx"},	\
+		{0x00008000, "woss"},	\
+		{0x00010000, "woli"})
+
+TRACE_EVENT(rros_thread_update_mode,
+	TP_PROTO(const char *element_name, int mode, bool set),
+	TP_ARGS(element_name, mode, set),
+	TP_STRUCT__entry(
+		__string(element_name, element_name)
+		__field(int, mode)
+		__field(bool, set)
+	),
+	TP_fast_assign(
+		__assign_str(element_name,element_name);
+		__entry->mode = mode;
+		__entry->set = set;
+	),
+	TP_printk("thread=%s %s %#x(%s)",
+		  __get_str(element_name),
+		  __entry->set ? "set" : "clear",
+		  __entry->mode, rros_print_thread_mode(__entry->mode))
+);
+
+DEFINE_EVENT(rros_clock_timespec, rros_clock_getres,
+	TP_PROTO(const char *clock_name, const struct timespec64 *val),
+	TP_ARGS(clock_name, val)
+);
+
+DEFINE_EVENT(rros_clock_timespec, rros_clock_gettime,
+	TP_PROTO(const char *clock_name, const struct timespec64 *val),
+	TP_ARGS(clock_name, val)
+);
+
+DEFINE_EVENT(rros_clock_timespec, rros_clock_settime,
+	TP_PROTO(const char *clock_name, const struct timespec64 *val),
+	TP_ARGS(clock_name, val)
+);
+
+TRACE_EVENT(rros_clock_adjtime,
+	TP_PROTO(const char *clock_name, struct __kernel_timex *tx),
+	TP_ARGS(clock_name, tx),
+
+	TP_STRUCT__entry(
+		__field(struct __kernel_timex *, tx)
+		__string(clock_name, clock_name)
+	),
+
+	TP_fast_assign(
+		__entry->tx = tx;
+		__assign_str(clock_name, clock_name);
+	),
+
+	TP_printk("clock=%s timex=%p",
+		  __get_str(clock_name),
+		  __entry->tx
+	)
+);
+
+DEFINE_EVENT(rros_clock_ident, rros_register_clock,
+	TP_PROTO(const char *name),
+	TP_ARGS(name)
+);
+
+DEFINE_EVENT(rros_clock_ident, rros_unregister_clock,
+	TP_PROTO(const char *name),
+	TP_ARGS(name)
+);
+
+TRACE_EVENT(rros_trace,
+	TP_PROTO(const char *msg),
+	TP_ARGS(msg),
+	TP_STRUCT__entry(
+		__string(msg, msg)
+	),
+	TP_fast_assign(
+		__assign_str(msg, msg);
+	),
+	TP_printk("%s", __get_str(msg))
+);
+
+#endif /* _TRACE_RROS_H */
+
+/* This part must be outside protection */
+#include <trace/define_trace.h>

--- a/include/trace/events/rros.h
+++ b/include/trace/events/rros.h
@@ -831,6 +831,46 @@ TRACE_EVENT(rros_trace,
 	TP_printk("%s", __get_str(msg))
 );
 
+TRACE_EVENT(rros_latspot,
+	TP_PROTO(int latmax_ns),
+	TP_ARGS(latmax_ns),
+	TP_STRUCT__entry(
+		 __field(int, latmax_ns)
+	),
+	TP_fast_assign(
+		__entry->latmax_ns = latmax_ns;
+	),
+	TP_printk("** latency peak: %d.%.3d us **",
+		  __entry->latmax_ns / 1000,
+		  __entry->latmax_ns % 1000)
+);
+
+TRACE_EVENT(rros_fpu_corrupt,
+	TP_PROTO(unsigned int fp_val),
+	TP_ARGS(fp_val),
+	TP_STRUCT__entry(
+		 __field(unsigned int, fp_val)
+	),
+	TP_fast_assign(
+		__entry->fp_val = fp_val;
+	),
+	TP_printk("** bad FPU context: fp_val = %u **",
+		__entry->fp_val)
+);
+
+/* Basically evl_trace() + trigger point */
+TRACE_EVENT(rros_trigger,
+	TP_PROTO(const char *issuer),
+	TP_ARGS(issuer),
+	TP_STRUCT__entry(
+		__string(issuer, issuer)
+	),
+	TP_fast_assign(
+		__assign_str(issuer, issuer);
+	),
+	TP_printk("%s", __get_str(issuer))
+);
+
 #endif /* _TRACE_RROS_H */
 
 /* This part must be outside protection */

--- a/kernel/rros/Makefile
+++ b/kernel/rros/Makefile
@@ -1,1 +1,2 @@
-﻿obj-y				+= init.o
+﻿obj-y				+= c_trace.o
+obj-y				+= init.o

--- a/kernel/rros/c_trace.c
+++ b/kernel/rros/c_trace.c
@@ -1,0 +1,325 @@
+#define CREATE_TRACE_POINTS
+#include <trace/events/rros.h>
+
+#define copy_on_stack(dst,src) \
+char dst[src.iov_len+1]; \
+strncpy(dst,src.iov_base,src.iov_len); \
+dst[src.iov_len] = 0;
+
+void rust_helper_trace_rros_schedule(unsigned long flags,unsigned long local_flags)
+{
+        trace_rros_schedule(flags,local_flags);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_schedule);
+
+void rust_helper_trace_rros_reschedule_ipi(unsigned long flags,unsigned long local_flags)
+{
+        trace_rros_reschedule_ipi(flags,local_flags);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_reschedule_ipi);
+
+void rust_helper_trace_rros_pick_thread(struct iovec  name_struct,pid_t next_pid)
+{
+        copy_on_stack(name,name_struct);
+        trace_rros_pick_thread(name,next_pid);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_pick_thread);
+
+void rust_helper_trace_rros_switch_context(struct iovec prev_name_struct,struct iovec next_name_struct,pid_t prev_pid,int prev_prio,u32 prev_state,pid_t next_pid,int next_prio)
+{
+        copy_on_stack(prev_name,prev_name_struct);
+        copy_on_stack(next_name,next_name_struct);
+        trace_rros_switch_context(prev_name,next_name,prev_pid,prev_prio,prev_state,next_pid,next_prio);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_switch_context);
+
+void rust_helper_trace_rros_switch_tail(struct iovec  curr_name_struct,pid_t curr_pid)
+{
+        copy_on_stack(curr_name,curr_name_struct);
+        trace_rros_switch_tail(curr_name,curr_pid);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_switch_tail);
+
+void rust_helper_trace_rros_init_thread(void*  thread,struct iovec  thread_name_struct,struct iovec class_name_struct,  unsigned long flags, int cprio,int status)
+{
+        copy_on_stack(thread_name,thread_name_struct);
+        copy_on_stack(class_name,class_name_struct);
+        trace_rros_init_thread(thread,thread_name,class_name,flags,cprio,status);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_init_thread);
+
+void rust_helper_trace_rros_sleep_on(pid_t pid,ktime_t timeout,   int timeout_mode, void * wchan,struct iovec  clock_name_struct,   struct iovec  wchan_name_struct)
+{
+        copy_on_stack(clock_name,clock_name_struct);
+        copy_on_stack(wchan_name,wchan_name_struct);
+        trace_rros_sleep_on(pid,timeout,timeout_mode,wchan,clock_name,wchan_name);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_sleep_on);
+
+void rust_helper_trace_rros_wakeup_thread(struct iovec thread_name_struct,pid_t pid, int mask, int info)
+{
+        copy_on_stack(thread_name,thread_name_struct);
+        trace_rros_wakeup_thread(thread_name,pid,mask,info);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_wakeup_thread);
+
+void rust_helper_trace_rros_hold_thread(struct iovec thread_name_struct,pid_t pid, unsigned long mask)
+{
+        copy_on_stack(thread_name,thread_name_struct);
+        trace_rros_hold_thread(thread_name,pid,mask);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_hold_thread);
+
+void rust_helper_trace_rros_release_thread(struct iovec thread_name_struct,pid_t pid, int mask, int info)
+{
+        copy_on_stack(thread_name,thread_name_struct);
+        trace_rros_release_thread(thread_name,pid,mask,info);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_release_thread);
+
+void rust_helper_trace_rros_thread_set_current_prio(void * thread,pid_t pid, int cprio)
+{
+        trace_rros_thread_set_current_prio(thread,pid,cprio);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_set_current_prio);
+
+void rust_helper_trace_rros_thread_cancel(pid_t pid,u32 state,u32 info)
+{
+        trace_rros_thread_cancel(pid,state,info);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_cancel);
+
+void rust_helper_trace_rros_thread_join(int pid,u32 state,u32 info)
+{
+        trace_rros_thread_join(pid,state,info);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_join);
+
+void rust_helper_trace_rros_unblock_thread(int pid,u32 state,u32 info)
+{
+        trace_rros_unblock_thread(pid,state,info);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_unblock_thread);
+
+void rust_helper_trace_rros_thread_wait_period(u32 state,u32 info)
+{
+        trace_rros_thread_wait_period(state,info);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_wait_period);
+
+void rust_helper_trace_rros_thread_missed_period(u32 state,u32 info)
+{
+        trace_rros_thread_missed_period(state,info);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_missed_period);
+
+void rust_helper_trace_rros_thread_migrate(void * thread,pid_t pid,unsigned int cpu)
+{
+        trace_rros_thread_migrate(thread,pid,cpu);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_migrate);
+
+void rust_helper_trace_rros_watchdog_signal(u32 state,u32 info)
+{
+        trace_rros_watchdog_signal(state,info);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_watchdog_signal);
+
+void rust_helper_trace_rros_switch_oob(u32 state,u32 info)
+{
+        trace_rros_switch_oob(state,info);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_switch_oob);
+
+void rust_helper_trace_rros_switched_oob(u32 state,u32 info)
+{
+        trace_rros_switched_oob(state,info);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_switched_oob);
+
+void rust_helper_trace_rros_switch_inband(int cause)
+{
+        trace_rros_switch_inband(cause);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_switch_inband);
+
+void rust_helper_trace_rros_switched_inband(u32 state,u32 info)
+{
+        trace_rros_switched_inband(state,info);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_switched_inband);
+
+void rust_helper_trace_rros_kthread_entry(u32 state,u32 info)
+{
+        trace_rros_kthread_entry(state,info);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_kthread_entry);
+
+void rust_helper_trace_rros_thread_map(void*  thread,pid_t pid,int prio)
+{
+        trace_rros_thread_map(thread,pid,prio);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_map);
+
+void rust_helper_trace_rros_thread_unmap(u32 state,u32 info)
+{
+        trace_rros_thread_unmap(state,info);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_unmap);
+
+void rust_helper_trace_rros_inband_wakeup(pid_t pid,char*  comm)
+{
+        trace_rros_inband_wakeup(pid,comm);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_inband_wakeup);
+
+void rust_helper_trace_rros_inband_signal(struct iovec element_name_struct,pid_t pid, int sig, int sigval)
+{
+        copy_on_stack(element_name,element_name_struct);
+        trace_rros_inband_signal(element_name,pid,sig,sigval);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_inband_signal);
+
+void rust_helper_trace_rros_timer_stop(struct iovec name_struct)
+{
+        copy_on_stack(name,name_struct);
+        trace_rros_timer_stop(name);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_timer_stop);
+
+void rust_helper_trace_rros_timer_expire(struct iovec name_struct)
+{
+        copy_on_stack(name,name_struct);
+        trace_rros_timer_expire(name);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_timer_expire);
+
+void rust_helper_trace_rros_timer_start(struct iovec timer_name_struct, ktime_t value, ktime_t interval)
+{
+        copy_on_stack(timer_name,timer_name_struct);
+        trace_rros_timer_start(timer_name,value,interval);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_timer_start);
+
+void rust_helper_trace_rros_timer_move(struct iovec  timer_name_struct,   struct iovec  clock_name_struct,   unsigned int cpu)
+{
+        copy_on_stack(timer_name,timer_name_struct);
+        copy_on_stack(clock_name,clock_name_struct);
+        trace_rros_timer_move(timer_name,clock_name,cpu);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_timer_move);
+
+void rust_helper_trace_rros_timer_shot(struct iovec  timer_name_struct, s64 delta, u64 cycles)
+{
+        copy_on_stack(timer_name,timer_name_struct);
+        trace_rros_timer_shot(timer_name,delta,cycles);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_timer_shot);
+
+void rust_helper_trace_rros_wait(struct iovec name_struct)
+{
+        copy_on_stack(name,name_struct);
+        trace_rros_wait(name);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_wait);
+
+void rust_helper_trace_rros_wake_up(struct iovec name_struct)
+{
+        copy_on_stack(name,name_struct);
+        trace_rros_wake_up(name);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_wake_up);
+
+void rust_helper_trace_rros_flush_wait(struct iovec name_struct)
+{
+        copy_on_stack(name,name_struct);
+        trace_rros_flush_wait(name);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_flush_wait);
+
+void rust_helper_trace_rros_finish_wait(struct iovec name_struct)
+{
+        copy_on_stack(name,name_struct);
+        trace_rros_finish_wait(name);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_finish_wait);
+
+void rust_helper_trace_rros_oob_sysentry(unsigned int nr)
+{
+        trace_rros_oob_sysentry(nr);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_oob_sysentry);
+
+void rust_helper_trace_rros_oob_sysexit(long result)
+{
+        trace_rros_oob_sysexit(result);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_oob_sysexit);
+
+void rust_helper_trace_rros_inband_sysentry(unsigned int nr)
+{
+        trace_rros_inband_sysentry(nr);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_inband_sysentry);
+
+void rust_helper_trace_rros_inband_sysexit(long result)
+{
+        trace_rros_inband_sysexit(result);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_inband_sysexit);
+
+void rust_helper_trace_rros_thread_update_mode(struct iovec element_name_struct, int mode, bool set)
+{
+        copy_on_stack(element_name,element_name_struct);
+        trace_rros_thread_update_mode(element_name,mode,set);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_update_mode);
+
+void rust_helper_trace_rros_clock_getres(struct iovec clock_name_struct, const struct timespec64 * val)
+{
+        copy_on_stack(clock_name,clock_name_struct);
+        trace_rros_clock_getres(clock_name,val);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_clock_getres);
+
+void rust_helper_trace_rros_clock_gettime(struct iovec clock_name_struct, const struct timespec64 * val)
+{
+        copy_on_stack(clock_name,clock_name_struct);
+        trace_rros_clock_gettime(clock_name,val);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_clock_gettime);
+
+void rust_helper_trace_rros_clock_settime(struct iovec clock_name_struct, const struct timespec64 * val)
+{
+        copy_on_stack(clock_name,clock_name_struct);
+        trace_rros_clock_settime(clock_name,val);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_clock_settime);
+
+void rust_helper_trace_rros_clock_adjtime(struct iovec clock_name_struct, struct __kernel_timex * tx)
+{
+        copy_on_stack(clock_name,clock_name_struct);
+        trace_rros_clock_adjtime(clock_name,tx);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_clock_adjtime);
+
+void rust_helper_trace_rros_register_clock(struct iovec name_struct)
+{
+        copy_on_stack(name,name_struct);
+        trace_rros_register_clock(name);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_register_clock);
+
+void rust_helper_trace_rros_unregister_clock(struct iovec name_struct)
+{
+        copy_on_stack(name,name_struct);
+        trace_rros_unregister_clock(name);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_unregister_clock);
+
+void rust_helper_trace_rros_trace(struct iovec msg_struct)
+{
+        copy_on_stack(msg,msg_struct);
+        trace_rros_trace(msg);
+}
+EXPORT_SYMBOL_GPL(rust_helper_trace_rros_trace);

--- a/kernel/rros/c_trace.c
+++ b/kernel/rros/c_trace.c
@@ -1,5 +1,6 @@
 #define CREATE_TRACE_POINTS
 #include <trace/events/rros.h>
+#include <uapi/linux/uio.h>
 
 #define copy_on_stack(dst,src) \
 char dst[src.iov_len+1]; \

--- a/kernel/rros/c_trace.c
+++ b/kernel/rros/c_trace.c
@@ -7,320 +7,609 @@ char dst[src.iov_len+1]; \
 strncpy(dst,src.iov_base,src.iov_len); \
 dst[src.iov_len] = 0;
 
-void rust_helper_trace_rros_schedule(unsigned long flags,unsigned long local_flags)
+/**
+ * @flags:                      Flags value.
+ * @local_flags:                Local flags value.
+*/
+void rust_helper_trace_rros_schedule(unsigned long flags,
+				     unsigned long local_flags)
 {
-        trace_rros_schedule(flags,local_flags);
+	trace_rros_schedule(flags, local_flags);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_schedule);
 
-void rust_helper_trace_rros_reschedule_ipi(unsigned long flags,unsigned long local_flags)
+/**
+ * @flags:                      Flags value.
+ * @local_flags:                Local flags value.
+*/
+void rust_helper_trace_rros_reschedule_ipi(unsigned long flags,
+					   unsigned long local_flags)
 {
-        trace_rros_reschedule_ipi(flags,local_flags);
+	trace_rros_reschedule_ipi(flags, local_flags);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_reschedule_ipi);
 
-void rust_helper_trace_rros_pick_thread(struct iovec  name_struct,pid_t next_pid)
+/**
+ * @name_struct:        Next thread name string represented by iovec.
+ * @next_pid:           Next thread pid.
+ */
+void rust_helper_trace_rros_pick_thread(struct iovec name_struct,
+					pid_t next_pid)
 {
-        copy_on_stack(name,name_struct);
-        trace_rros_pick_thread(name,next_pid);
+	copy_on_stack(name, name_struct);
+	trace_rros_pick_thread(name, next_pid);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_pick_thread);
 
-void rust_helper_trace_rros_switch_context(struct iovec prev_name_struct,struct iovec next_name_struct,pid_t prev_pid,int prev_prio,u32 prev_state,pid_t next_pid,int next_prio)
+/**
+ * @prev_name_struct:           Previous thread name string represented by iovec.
+ * @next_name_struct:           Next thread name string represented by iovec.
+ * @prev_pid:                   Previous thread pid.
+ * @next_pid:                   Next thread pid.
+ * @prev_prio:                  The priority of previous thread.
+ * @prev_state:                 The state of previous thread.                            
+ * @next_prio:                  The priority of next thread.
+ */
+void rust_helper_trace_rros_switch_context(struct iovec prev_name_struct,
+					   struct iovec next_name_struct,
+					   pid_t prev_pid, int prev_prio,
+					   u32 prev_state, pid_t next_pid,
+					   int next_prio)
 {
-        copy_on_stack(prev_name,prev_name_struct);
-        copy_on_stack(next_name,next_name_struct);
-        trace_rros_switch_context(prev_name,next_name,prev_pid,prev_prio,prev_state,next_pid,next_prio);
+	copy_on_stack(prev_name, prev_name_struct);
+	copy_on_stack(next_name, next_name_struct);
+	trace_rros_switch_context(prev_name, next_name, prev_pid, prev_prio,
+				  prev_state, next_pid, next_prio);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_switch_context);
 
-void rust_helper_trace_rros_switch_tail(struct iovec  curr_name_struct,pid_t curr_pid)
+/**
+ * @curr_name_struct:           Current thread name string represented by iovec.
+ * @curr_pid:                   Current thread pid.
+ */
+void rust_helper_trace_rros_switch_tail(struct iovec curr_name_struct,
+					pid_t curr_pid)
 {
-        copy_on_stack(curr_name,curr_name_struct);
-        trace_rros_switch_tail(curr_name,curr_pid);
+	copy_on_stack(curr_name, curr_name_struct);
+	trace_rros_switch_tail(curr_name, curr_pid);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_switch_tail);
 
-void rust_helper_trace_rros_init_thread(void*  thread,struct iovec  thread_name_struct,struct iovec class_name_struct,  unsigned long flags, int cprio,int status)
+/**
+ * @thread:                     Thread pointer.
+ * @thread_name_struct:         Thread name string represented by iovec.
+ * @class_name_struct:          Class name string represented by iovec.
+ * @flags:                      Flags.
+ * @cprio:                      Current priority.
+ * @status:                     Status.
+*/
+void rust_helper_trace_rros_init_thread(void *thread,
+					struct iovec thread_name_struct,
+					struct iovec class_name_struct,
+					unsigned long flags, int cprio,
+					int status)
 {
-        copy_on_stack(thread_name,thread_name_struct);
-        copy_on_stack(class_name,class_name_struct);
-        trace_rros_init_thread(thread,thread_name,class_name,flags,cprio,status);
+	copy_on_stack(thread_name, thread_name_struct);
+	copy_on_stack(class_name, class_name_struct);
+	trace_rros_init_thread(thread, thread_name, class_name, flags, cprio,
+			       status);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_init_thread);
 
-void rust_helper_trace_rros_sleep_on(pid_t pid,ktime_t timeout,   int timeout_mode, void * wchan,struct iovec  clock_name_struct,   struct iovec  wchan_name_struct)
+/**
+ * @pid:                       Thread pid.
+ * @timeout:                   Timeout value.
+ * @timeout_mode:              Timeout mode.
+ * @wchan:                     Wait channel pointer.
+ * @clock_name_struct:         Clock name string represented by iovec.
+ * @wchan_name_struct:         Wait channel name string represented by iovec.
+*/
+void rust_helper_trace_rros_sleep_on(pid_t pid, ktime_t timeout,
+				     int timeout_mode, void *wchan,
+				     struct iovec clock_name_struct,
+				     struct iovec wchan_name_struct)
 {
-        copy_on_stack(clock_name,clock_name_struct);
-        copy_on_stack(wchan_name,wchan_name_struct);
-        trace_rros_sleep_on(pid,timeout,timeout_mode,wchan,clock_name,wchan_name);
+	copy_on_stack(clock_name, clock_name_struct);
+	copy_on_stack(wchan_name, wchan_name_struct);
+	trace_rros_sleep_on(pid, timeout, timeout_mode, wchan, clock_name,
+			    wchan_name);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_sleep_on);
 
-void rust_helper_trace_rros_wakeup_thread(struct iovec thread_name_struct,pid_t pid, int mask, int info)
+/**
+ * @thread_name_struct:        Thread name string represented by iovec.
+ * @pid:                       Thread pid.
+ * @mask:                      Mask value.
+ * @info:                      Info value.
+*/
+void rust_helper_trace_rros_wakeup_thread(struct iovec thread_name_struct,
+					  pid_t pid, int mask, int info)
 {
-        copy_on_stack(thread_name,thread_name_struct);
-        trace_rros_wakeup_thread(thread_name,pid,mask,info);
+	copy_on_stack(thread_name, thread_name_struct);
+	trace_rros_wakeup_thread(thread_name, pid, mask, info);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_wakeup_thread);
 
-void rust_helper_trace_rros_hold_thread(struct iovec thread_name_struct,pid_t pid, unsigned long mask)
+/**
+ * @thread_name_struct:        Thread name string represented by iovec.
+ * @pid:                       Thread pid.
+ * @mask:                      Mask value.
+*/
+void rust_helper_trace_rros_hold_thread(struct iovec thread_name_struct,
+					pid_t pid, unsigned long mask)
 {
-        copy_on_stack(thread_name,thread_name_struct);
-        trace_rros_hold_thread(thread_name,pid,mask);
+	copy_on_stack(thread_name, thread_name_struct);
+	trace_rros_hold_thread(thread_name, pid, mask);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_hold_thread);
 
-void rust_helper_trace_rros_release_thread(struct iovec thread_name_struct,pid_t pid, int mask, int info)
+/**
+ * @thread_name_struct:         Thread name string represented by iovec.
+ * @pid:                        Thread pid.
+ * @mask:                       Mask value.
+ * @info:                       Info value.
+*/
+void rust_helper_trace_rros_release_thread(struct iovec thread_name_struct,
+					   pid_t pid, int mask, int info)
 {
-        copy_on_stack(thread_name,thread_name_struct);
-        trace_rros_release_thread(thread_name,pid,mask,info);
+	copy_on_stack(thread_name, thread_name_struct);
+	trace_rros_release_thread(thread_name, pid, mask, info);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_release_thread);
 
-void rust_helper_trace_rros_thread_set_current_prio(void * thread,pid_t pid, int cprio)
+/**
+ * @thread:                     Thread pointer.
+ * @pid:                        Thread pid.
+ * @cprio:                      Current priority.
+*/
+void rust_helper_trace_rros_thread_set_current_prio(void *thread, pid_t pid,
+						    int cprio)
 {
-        trace_rros_thread_set_current_prio(thread,pid,cprio);
+	trace_rros_thread_set_current_prio(thread, pid, cprio);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_set_current_prio);
 
-void rust_helper_trace_rros_thread_cancel(pid_t pid,u32 state,u32 info)
+/**
+ * @pid:                        Thread pid.
+ * @state:                      State value.
+ * @info:                       Info value.
+*/
+void rust_helper_trace_rros_thread_cancel(pid_t pid, u32 state, u32 info)
 {
-        trace_rros_thread_cancel(pid,state,info);
+	trace_rros_thread_cancel(pid, state, info);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_cancel);
 
-void rust_helper_trace_rros_thread_join(int pid,u32 state,u32 info)
+/**
+ * @pid:                        Thread pid.
+ * @state:                      State value.
+ * @info:                       Info value.      
+*/
+void rust_helper_trace_rros_thread_join(int pid, u32 state, u32 info)
 {
-        trace_rros_thread_join(pid,state,info);
+	trace_rros_thread_join(pid, state, info);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_join);
 
-void rust_helper_trace_rros_unblock_thread(int pid,u32 state,u32 info)
+/**
+ * @pid:                        Thread pid.
+ * @state:                      State value.
+ * @info:                       Info value.
+*/
+void rust_helper_trace_rros_unblock_thread(int pid, u32 state, u32 info)
 {
-        trace_rros_unblock_thread(pid,state,info);
+	trace_rros_unblock_thread(pid, state, info);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_unblock_thread);
 
-void rust_helper_trace_rros_thread_wait_period(u32 state,u32 info)
+/**
+ * @state:                      State value.
+ * @info:                       Info value.       
+*/
+void rust_helper_trace_rros_thread_wait_period(u32 state, u32 info)
 {
-        trace_rros_thread_wait_period(state,info);
+	trace_rros_thread_wait_period(state, info);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_wait_period);
 
-void rust_helper_trace_rros_thread_missed_period(u32 state,u32 info)
+/**
+ * @state:                      State value.
+ * @info:                       Info value.
+*/
+void rust_helper_trace_rros_thread_missed_period(u32 state, u32 info)
 {
-        trace_rros_thread_missed_period(state,info);
+	trace_rros_thread_missed_period(state, info);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_missed_period);
 
-void rust_helper_trace_rros_thread_migrate(void * thread,pid_t pid,unsigned int cpu)
+/**
+ * @thread:                     Thread pointer.
+ * @pid:                        Thread pid.
+ * @cpu:                        CPU number.
+*/
+void rust_helper_trace_rros_thread_migrate(void *thread, pid_t pid,
+					   unsigned int cpu)
 {
-        trace_rros_thread_migrate(thread,pid,cpu);
+	trace_rros_thread_migrate(thread, pid, cpu);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_migrate);
 
-void rust_helper_trace_rros_watchdog_signal(u32 state,u32 info)
+/**
+ * @state:                      State value.
+ * @info:                       Info value.
+*/
+void rust_helper_trace_rros_watchdog_signal(u32 state, u32 info)
 {
-        trace_rros_watchdog_signal(state,info);
+	trace_rros_watchdog_signal(state, info);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_watchdog_signal);
 
-void rust_helper_trace_rros_switch_oob(u32 state,u32 info)
+/**
+ * @state:                      State value.
+ * @info:                       Info value.
+*/
+void rust_helper_trace_rros_switch_oob(u32 state, u32 info)
 {
-        trace_rros_switch_oob(state,info);
+	trace_rros_switch_oob(state, info);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_switch_oob);
 
-void rust_helper_trace_rros_switched_oob(u32 state,u32 info)
+/**
+ * @state:                      State value.
+ * @info:                       Info value.
+*/
+void rust_helper_trace_rros_switched_oob(u32 state, u32 info)
 {
-        trace_rros_switched_oob(state,info);
+	trace_rros_switched_oob(state, info);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_switched_oob);
 
+/**
+ * @cause:                      Cause reason value.
+*/
 void rust_helper_trace_rros_switch_inband(int cause)
 {
-        trace_rros_switch_inband(cause);
+	trace_rros_switch_inband(cause);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_switch_inband);
 
-void rust_helper_trace_rros_switched_inband(u32 state,u32 info)
+/**
+ * @state:                      State value.
+ * @info:                       Info value.
+*/
+void rust_helper_trace_rros_switched_inband(u32 state, u32 info)
 {
-        trace_rros_switched_inband(state,info);
+	trace_rros_switched_inband(state, info);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_switched_inband);
 
-void rust_helper_trace_rros_kthread_entry(u32 state,u32 info)
+/**
+ * @state:                      State value.
+ * @info:                       Info value.
+*/
+void rust_helper_trace_rros_kthread_entry(u32 state, u32 info)
 {
-        trace_rros_kthread_entry(state,info);
+	trace_rros_kthread_entry(state, info);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_kthread_entry);
 
-void rust_helper_trace_rros_thread_map(void*  thread,pid_t pid,int prio)
+/**
+ * @thread:                     Thread pointer.
+ * @pid:                        Thread pid.
+ * @prio:                       Priority value.
+*/
+void rust_helper_trace_rros_thread_map(void *thread, pid_t pid, int prio)
 {
-        trace_rros_thread_map(thread,pid,prio);
+	trace_rros_thread_map(thread, pid, prio);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_map);
 
-void rust_helper_trace_rros_thread_unmap(u32 state,u32 info)
+/**
+ * @state:                      State value.
+ * @info:                       Info value.
+*/
+void rust_helper_trace_rros_thread_unmap(u32 state, u32 info)
 {
-        trace_rros_thread_unmap(state,info);
+	trace_rros_thread_unmap(state, info);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_unmap);
 
-void rust_helper_trace_rros_inband_wakeup(pid_t pid,char*  comm)
+/**
+ * @pid:                        Thread pid.
+ * @comm:						Comm value pointer.
+*/
+void rust_helper_trace_rros_inband_wakeup(pid_t pid, char *comm)
 {
-        trace_rros_inband_wakeup(pid,comm);
+	trace_rros_inband_wakeup(pid, comm);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_inband_wakeup);
 
-void rust_helper_trace_rros_inband_signal(struct iovec element_name_struct,pid_t pid, int sig, int sigval)
+/**
+ * @element_name_struct:        Element name string represented by iovec.
+ * @pid:                        Thread pid.
+ * @sig:                        Signal value.
+*/
+void rust_helper_trace_rros_inband_signal(struct iovec element_name_struct,
+					  pid_t pid, int sig, int sigval)
 {
-        copy_on_stack(element_name,element_name_struct);
-        trace_rros_inband_signal(element_name,pid,sig,sigval);
+	copy_on_stack(element_name, element_name_struct);
+	trace_rros_inband_signal(element_name, pid, sig, sigval);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_inband_signal);
 
+/**
+ * @name_struct:                Name string represented by iovec.
+*/
 void rust_helper_trace_rros_timer_stop(struct iovec name_struct)
 {
-        copy_on_stack(name,name_struct);
-        trace_rros_timer_stop(name);
+	copy_on_stack(name, name_struct);
+	trace_rros_timer_stop(name);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_timer_stop);
 
+/**
+ * @name_struct:                Name string represented by iovec.
+*/
 void rust_helper_trace_rros_timer_expire(struct iovec name_struct)
 {
-        copy_on_stack(name,name_struct);
-        trace_rros_timer_expire(name);
+	copy_on_stack(name, name_struct);
+	trace_rros_timer_expire(name);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_timer_expire);
 
-void rust_helper_trace_rros_timer_start(struct iovec timer_name_struct, ktime_t value, ktime_t interval)
+/**
+ * @timer_name_struct:          Timer name string represented by iovec.
+ * @value:                      Value.
+ * @interval:                   Interval time value.
+
+*/
+void rust_helper_trace_rros_timer_start(struct iovec timer_name_struct,
+					ktime_t value, ktime_t interval)
 {
-        copy_on_stack(timer_name,timer_name_struct);
-        trace_rros_timer_start(timer_name,value,interval);
+	copy_on_stack(timer_name, timer_name_struct);
+	trace_rros_timer_start(timer_name, value, interval);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_timer_start);
 
-void rust_helper_trace_rros_timer_move(struct iovec  timer_name_struct,   struct iovec  clock_name_struct,   unsigned int cpu)
+/**
+ * @timer_name_struct:          Timer name string represented by iovec.
+ * @clock_name_struct:          Clock name string represented by iovec.
+ * @cpu:                        CPU number.
+*/
+void rust_helper_trace_rros_timer_move(struct iovec timer_name_struct,
+				       struct iovec clock_name_struct,
+				       unsigned int cpu)
 {
-        copy_on_stack(timer_name,timer_name_struct);
-        copy_on_stack(clock_name,clock_name_struct);
-        trace_rros_timer_move(timer_name,clock_name,cpu);
+	copy_on_stack(timer_name, timer_name_struct);
+	copy_on_stack(clock_name, clock_name_struct);
+	trace_rros_timer_move(timer_name, clock_name, cpu);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_timer_move);
 
-void rust_helper_trace_rros_timer_shot(struct iovec  timer_name_struct, s64 delta, u64 cycles)
+/**
+ * @timer_name_struct:          Timer name string represented by iovec.
+ * @delta:                      Delta value.
+ * @cycles:                     Cycles value.
+*/
+void rust_helper_trace_rros_timer_shot(struct iovec timer_name_struct,
+				       s64 delta, u64 cycles)
 {
-        copy_on_stack(timer_name,timer_name_struct);
-        trace_rros_timer_shot(timer_name,delta,cycles);
+	copy_on_stack(timer_name, timer_name_struct);
+	trace_rros_timer_shot(timer_name, delta, cycles);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_timer_shot);
 
+/**
+ * @name_struct:                Name string represented by iovec.
+*/
 void rust_helper_trace_rros_wait(struct iovec name_struct)
 {
-        copy_on_stack(name,name_struct);
-        trace_rros_wait(name);
+	copy_on_stack(name, name_struct);
+	trace_rros_wait(name);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_wait);
 
+/**
+ * @name_struct:                Name string represented by iovec.
+*/
 void rust_helper_trace_rros_wake_up(struct iovec name_struct)
 {
-        copy_on_stack(name,name_struct);
-        trace_rros_wake_up(name);
+	copy_on_stack(name, name_struct);
+	trace_rros_wake_up(name);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_wake_up);
 
+/**
+ * @name_struct:                Name string represented by iovec.
+*/
 void rust_helper_trace_rros_flush_wait(struct iovec name_struct)
 {
-        copy_on_stack(name,name_struct);
-        trace_rros_flush_wait(name);
+	copy_on_stack(name, name_struct);
+	trace_rros_flush_wait(name);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_flush_wait);
 
+/**
+ * @name_struct:                Name string represented by iovec.
+*/
 void rust_helper_trace_rros_finish_wait(struct iovec name_struct)
 {
-        copy_on_stack(name,name_struct);
-        trace_rros_finish_wait(name);
+	copy_on_stack(name, name_struct);
+	trace_rros_finish_wait(name);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_finish_wait);
 
+/**
+ * @nr:						Syscall number.
+*/
 void rust_helper_trace_rros_oob_sysentry(unsigned int nr)
 {
-        trace_rros_oob_sysentry(nr);
+	trace_rros_oob_sysentry(nr);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_oob_sysentry);
 
+/**
+ * @result:					Result value.
+*/
 void rust_helper_trace_rros_oob_sysexit(long result)
 {
-        trace_rros_oob_sysexit(result);
+	trace_rros_oob_sysexit(result);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_oob_sysexit);
 
+/**
+ * @nr:						Syscall number.
+*/
 void rust_helper_trace_rros_inband_sysentry(unsigned int nr)
 {
-        trace_rros_inband_sysentry(nr);
+	trace_rros_inband_sysentry(nr);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_inband_sysentry);
 
+/**
+ * @result:					Result value.
+*/
 void rust_helper_trace_rros_inband_sysexit(long result)
 {
-        trace_rros_inband_sysexit(result);
+	trace_rros_inband_sysexit(result);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_inband_sysexit);
 
-void rust_helper_trace_rros_thread_update_mode(struct iovec element_name_struct, int mode, bool set)
+/**
+ * @element_name_struct:        Element name string represented by iovec.
+ * @mode:                       Mode value.
+ * @set:                        Flag represented whether mode is set mode.
+*/
+void rust_helper_trace_rros_thread_update_mode(struct iovec element_name_struct,
+					       int mode, bool set)
 {
-        copy_on_stack(element_name,element_name_struct);
-        trace_rros_thread_update_mode(element_name,mode,set);
+	copy_on_stack(element_name, element_name_struct);
+	trace_rros_thread_update_mode(element_name, mode, set);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_thread_update_mode);
 
-void rust_helper_trace_rros_clock_getres(struct iovec clock_name_struct, const struct timespec64 * val)
+/**
+ * @clock_name_struct:          Clock name string represented by iovec.
+ * @val: 					  	Pointer to timespec64 structure.
+*/
+void rust_helper_trace_rros_clock_getres(struct iovec clock_name_struct,
+					 const struct timespec64 *val)
 {
-        copy_on_stack(clock_name,clock_name_struct);
-        trace_rros_clock_getres(clock_name,val);
+	copy_on_stack(clock_name, clock_name_struct);
+	trace_rros_clock_getres(clock_name, val);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_clock_getres);
 
-void rust_helper_trace_rros_clock_gettime(struct iovec clock_name_struct, const struct timespec64 * val)
+/**
+ * @clock_name_struct:          Clock name string represented by iovec.
+ * @val: 					  	Pointer to timespec64 structure.
+*/
+void rust_helper_trace_rros_clock_gettime(struct iovec clock_name_struct,
+					  const struct timespec64 *val)
 {
-        copy_on_stack(clock_name,clock_name_struct);
-        trace_rros_clock_gettime(clock_name,val);
+	copy_on_stack(clock_name, clock_name_struct);
+	trace_rros_clock_gettime(clock_name, val);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_clock_gettime);
 
-void rust_helper_trace_rros_clock_settime(struct iovec clock_name_struct, const struct timespec64 * val)
+/**
+ * @clock_name_struct:          Clock name string represented by iovec.
+ * @val: 					  	Pointer to timespec64 structure.
+*/
+void rust_helper_trace_rros_clock_settime(struct iovec clock_name_struct,
+					  const struct timespec64 *val)
 {
-        copy_on_stack(clock_name,clock_name_struct);
-        trace_rros_clock_settime(clock_name,val);
+	copy_on_stack(clock_name, clock_name_struct);
+	trace_rros_clock_settime(clock_name, val);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_clock_settime);
 
-void rust_helper_trace_rros_clock_adjtime(struct iovec clock_name_struct, struct __kernel_timex * tx)
+/**
+ * @clock_name_struct:          Clock name string represented by iovec.
+ * @tx: 					  	Pointer to __kernel_timex structure.
+*/
+void rust_helper_trace_rros_clock_adjtime(struct iovec clock_name_struct,
+					  struct __kernel_timex *tx)
 {
-        copy_on_stack(clock_name,clock_name_struct);
-        trace_rros_clock_adjtime(clock_name,tx);
+	copy_on_stack(clock_name, clock_name_struct);
+	trace_rros_clock_adjtime(clock_name, tx);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_clock_adjtime);
 
+/**
+ * @name_struct:                Name string represented by iovec.
+*/
 void rust_helper_trace_rros_register_clock(struct iovec name_struct)
 {
-        copy_on_stack(name,name_struct);
-        trace_rros_register_clock(name);
+	copy_on_stack(name, name_struct);
+	trace_rros_register_clock(name);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_register_clock);
 
+/**
+ * @name_struct:                Name string represented by iovec.
+*/
 void rust_helper_trace_rros_unregister_clock(struct iovec name_struct)
 {
-        copy_on_stack(name,name_struct);
-        trace_rros_unregister_clock(name);
+	copy_on_stack(name, name_struct);
+	trace_rros_unregister_clock(name);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_unregister_clock);
 
+/**
+ * @msg_str: 				 Message string represented by iovec.
+*/
 void rust_helper_trace_rros_trace(struct iovec msg_struct)
 {
-        copy_on_stack(msg,msg_struct);
-        trace_rros_trace(msg);
+	copy_on_stack(msg, msg_struct);
+	trace_rros_trace(msg);
 }
+
 EXPORT_SYMBOL_GPL(rust_helper_trace_rros_trace);

--- a/kernel/rros/c_trace.c
+++ b/kernel/rros/c_trace.c
@@ -3,9 +3,9 @@
 #include <uapi/linux/uio.h>
 
 #define copy_on_stack(dst,src) \
-char dst[src.iov_len+1]; \
-strncpy(dst,src.iov_base,src.iov_len); \
-dst[src.iov_len] = 0;
+	char dst[src.iov_len+1]; \
+	strncpy(dst,src.iov_base,src.iov_len); \
+	dst[src.iov_len] = 0;
 
 /**
  * @flags:                      Flags value.

--- a/kernel/rros/clock.rs
+++ b/kernel/rros/clock.rs
@@ -285,6 +285,10 @@ impl RrosClock {
     pub fn get_master(&self) -> *mut RrosClock {
         self.master
     }
+
+    pub fn get_name(&self) -> &'static CStr {
+        self.name
+    }
 }
 
 pub fn adjust_timer(

--- a/kernel/rros/init.rs
+++ b/kernel/rros/init.rs
@@ -18,6 +18,9 @@ use kernel::{
 use core::str;
 use core::sync::atomic::{AtomicU8, Ordering};
 
+#[allow(dead_code)]
+mod trace;
+
 mod control;
 mod idle;
 mod poll;

--- a/kernel/rros/thread.rs
+++ b/kernel/rros/thread.rs
@@ -2000,7 +2000,7 @@ unsafe extern "C" fn sig_irqwork(_work: *mut IrqWork) {
 // }
 
 #[allow(dead_code)]
-fn rros_get_inband_pid(thread: *mut RrosThread) -> i32 {
+pub fn rros_get_inband_pid(thread: *const RrosThread) -> i32 {
     unsafe {
         if (*thread).state & (T_ROOT | T_DORMANT | T_ZOMBIE) != 0 {
             return 0;

--- a/kernel/rros/timer.rs
+++ b/kernel/rros/timer.rs
@@ -170,6 +170,10 @@ impl RrosTimer {
         self.base
     }
 
+    pub fn get_name(&self) -> &CStr {
+        self.name
+    }
+
     #[cfg(CONFIG_RROS_RUNSTATS)]
     pub fn get_scheduled<'a>(&mut self) -> &'a mut RrosAccount {
         self.scheduled

--- a/kernel/rros/trace.rs
+++ b/kernel/rros/trace.rs
@@ -1,6 +1,90 @@
 // SPDX-License-Identifier: GPL-2.0
 // TODO: more flexible to use `trace!` macro.
 
+//! # FTRACE USAGE IN RROS
+//!
+//! *[See also the ftrace usage](https://www.kernel.org/doc/html/latest/trace/ftrace.html).*
+//!
+//! ## Kernel Configuration
+//!
+//! 1. **Tracing Support**:
+//!   - Enable `CONFIG_TRACING`. This is the core option for enabling the tracing infrastructure in the Linux kernel, which `ftrace` relies upon.
+//!
+//! 2. **Function Tracer (FTRACE)**:
+//!    - Enable `CONFIG_FUNCTION_TRACER`. This option is the fundamental requirement for `ftrace` to work, as it enables tracing of function calls within the kernel.
+//!
+//! 3. **Tracepoints**:
+//!    - Enable `CONFIG_TRACEPOINTS`. This option enables tracepoints that are statically defined in the kernel, allowing `ftrace` and other tools to hook into these points for detailed event information.
+//!
+//! 4. **Dynamic Ftrace**:
+//!    - Enable `CONFIG_DYNAMIC_FTRACE`. This allows for the dynamic modification of kernel code to insert/remove tracepoints, making `ftrace` more versatile and with minimal overhead.
+//!
+//! 5. **Function Graph Tracer**:
+//!    - Enable `CONFIG_FUNCTION_GRAPH_TRACER`. This option allows for graph tracing of function calls, which is useful for visualizing call stacks and understanding the flow of execution.
+//!
+//! 6. **Additional Tracers**:
+//!    - Depending on your needs, you may also enable additional tracers, such as:
+//!      - `CONFIG_SCHED_TRACER` for scheduling events,
+//!      - `CONFIG_IRQSOFF_TRACER` for tracing periods where interrupts are disabled,
+//!      - `CONFIG_PREEMPT_TRACER` for tracing preempt disable and enable events,
+//!      - and others depending on your specific tracing requirements.
+//!
+//! ## Basic usage in kernel code
+//!
+//! Use FFI helper functions for tracepoints. The `trace_rros_*` functions are used to trace the rros events.
+//!
+//! ```
+//! let rq = this_rros_rq();
+//! ```
+//!
+//! Here we get the `rq` of the current CPU, and then we can use the `rq` to trace the events.
+//! Then we could add the following code to trace the schedule event.
+//!
+//! ```
+//! trace_rros_schedule(&rq);
+//! ```
+//!
+//! ## Basic usage in user space tools
+//!
+//! 1. enable all the rros tracepoints in kernel.
+//!
+//! ```
+//! echo 1 > /sys/kernel/debug/tracing/events/rros/enable
+//! ```
+//!
+//! or enable the only one rros tracepoint.
+//!
+//! ```
+//! echo 1 > /sys/kernel/debug/tracing/events/rros/rros_schedule/enable
+//! ```
+//!
+//! or you could enable any tracepoints group you want.
+//!
+//! 2. start the program to emit the tracepoints.
+//!
+//! ```
+//! ./{test_program}
+//! ```
+//!
+//! 3. cat the trace.
+//!
+//! ```
+//! cat /sys/kernel/debug/tracing/trace | grep rros
+//!
+//! ```
+//!
+//! 4. use the data analysis tools to analyze the trace data.
+//!
+//! You could use the `trace-cmd` to trace the events, and use the `kernelshark` to analyze the trace data.
+//!
+//! # Note
+//!
+//! - You could resize the buffer size of the trace file in `/sys/kernel/debug/tracing/buffer_size_kb` if the trace file is too large.
+//!
+//! ```
+//! echo 1024 > /sys/kernel/debug/tracing/buffer_size_kb
+//! ```
+
 use core::ops::Deref;
 
 use kernel::bindings;

--- a/kernel/rros/trace.rs
+++ b/kernel/rros/trace.rs
@@ -1,0 +1,538 @@
+// SPDX-License-Identifier: GPL-2.0
+// TODO: 更易用的API
+
+use kernel::bindings;
+use kernel::ktime;
+use kernel::c_types::c_void;
+
+
+use crate::clock::RrosClock;
+use crate::timer::RrosTimer;
+use crate::wait::RrosWaitChannel;
+use crate::{sched::{rros_rq, RrosThread, RrosInitThreadAttr}, thread::rros_get_inband_pid};
+
+
+fn slice_to_iovec(array: &[u8]) -> bindings::iovec{
+    bindings::iovec{
+        iov_base: array.as_ptr() as *const _ as *mut c_void,
+        iov_len: array.len() as u64
+    }
+}
+
+
+pub fn trace_rros_schedule(rq:&rros_rq){
+    extern "C"{
+        fn rust_helper_trace_rros_schedule(flags:u64,local_flags:u64);
+    }
+    let flags = rq.flags;
+    let _local_flags = rq.flags;
+    unsafe{
+        rust_helper_trace_rros_schedule(flags,rq.flags);
+    }
+}
+pub fn trace_rros_reschedule_ipi(rq:&rros_rq){
+    extern "C"{
+        fn rust_helper_trace_rros_reschedule_ipi(flags:u64,local_flags:u64);
+    }
+    let flags = rq.flags;
+    let local_flags = rq.flags;
+    unsafe{
+        rust_helper_trace_rros_reschedule_ipi(flags, local_flags);
+    }
+}
+pub fn trace_rros_pick_thread(next:&RrosThread){
+    extern "C"{
+        fn rust_helper_trace_rros_pick_thread(name:bindings::iovec,next_pid:i32);
+    }
+    let _thread_name = [0u8;32];
+    let next_pid = rros_get_inband_pid(next as *const RrosThread);
+    unsafe{
+        let array = next.name.as_bytes();
+        let iov = slice_to_iovec(array);
+        rust_helper_trace_rros_pick_thread(iov,next_pid);
+    }
+}
+
+// TODO: prepare_rq_switch is not impl.
+pub fn trace_rros_switch_context(prev: &RrosThread, next: &RrosThread){
+    extern "C"{
+        fn rust_helper_trace_rros_switch_context(prev_name:bindings::iovec,next_name:bindings::iovec,prev_pid:u32,prev_prio:i32,prev_state:u32,next_pid:u32,next_prio:i32);
+    }
+
+    let _prev_thread_name = [0u8;32];
+    let _next_thread_name = [0u8;32];
+    
+    
+    let prev_array = prev.name.as_bytes();
+    let next_array = next.name.as_bytes();
+    let prev_iov = slice_to_iovec(prev_array);
+    let next_iov = slice_to_iovec(next_array);
+    
+
+    let prev_pid = rros_get_inband_pid(prev as *const RrosThread);
+    let next_pid = rros_get_inband_pid(next as *const RrosThread);
+
+    let prev_prio = prev.cprio;
+    let next_prio = next.cprio;
+
+    let prev_state = prev.state;
+
+    unsafe{
+        rust_helper_trace_rros_switch_context(prev_iov,next_iov,prev_pid as u32,prev_prio,prev_state,next_pid as u32,next_prio);
+    }
+}
+
+// TODO: finish_rq_switch is not impl.
+pub fn trace_rros_switch_tail(curr: &RrosThread){
+    extern "C"{
+        fn rust_helper_trace_rros_switch_tail(curr_name:bindings::iovec,curr_pid:u32);
+    }
+    let curr_pid = rros_get_inband_pid(curr);
+    let curr_array = curr.name.as_bytes();
+    let curr_iov = slice_to_iovec(curr_array);
+
+    unsafe{
+        rust_helper_trace_rros_switch_tail(curr_iov, curr_pid as u32);
+    }
+}
+pub fn trace_rros_init_thread(thread: &RrosThread, iattr: &RrosInitThreadAttr, status: i32){
+    extern "C"{
+        fn rust_helper_trace_rros_init_thread(thread:*mut c_void,thread_name:bindings::iovec,class_name:bindings::iovec,flags:u64,cprio:i32,status:i32);
+    }
+
+    let _thread_name = [0u8; 32];
+    let _class_name = [0u8; 32];
+
+    let thread_name_array = thread.name.as_bytes();
+    let class_name_array = iattr.sched_class.unwrap().name.as_bytes();
+    let thread_iov = slice_to_iovec(thread_name_array);
+    let class_iov = slice_to_iovec(class_name_array);
+    
+
+    let flags = iattr.flags;
+    let cprio = thread.cprio;
+    unsafe{
+        rust_helper_trace_rros_init_thread(thread as *const _ as *mut c_void,thread_iov,class_iov,flags as u64,cprio,status as i32);
+    }
+}
+// NOTE: RrosClock.name is private, so add `get_name()` for RrosClock.
+// TODO: rros_sleep_on_locked is not impl. We use the unsafe code `evl_delay`.
+pub fn trace_rros_sleep_on(thread: &RrosThread, timeout: ktime::KtimeT, timeout_mode: i32, wchan: *mut RrosWaitChannel, clock: &RrosClock){
+    extern "C"{
+        fn rust_helper_trace_rros_sleep_on(pid:u32,timeout:bindings::ktime_t,timeout_mode:i32,wchan:*mut c_void,clock_name:bindings::iovec,wchan_name:bindings::iovec);
+    }
+    let clock_name = clock.get_name();
+    let clock_array = clock_name.as_bytes();
+    let clock_iov = slice_to_iovec(clock_array);
+    let pid = rros_get_inband_pid(thread as *const RrosThread);
+    // TODO: unknown fileds `wchan_name`
+    let wchan_name = slice_to_iovec("unknown fileds".as_bytes());
+    unsafe{
+        rust_helper_trace_rros_sleep_on(pid as u32,timeout,timeout_mode,wchan as *mut _ as *mut  c_void,clock_iov,wchan_name);
+    }
+}
+pub fn trace_rros_wakeup_thread(thread: &RrosThread, mask: u32, _info: i32){
+    extern "C"{
+        fn rust_helper_trace_rros_wakeup_thread(thread_name:bindings::iovec,pid:u32,mask:i32,info:i32);
+    }
+    let thread_array = thread.name.as_bytes();
+    let thread_iov = slice_to_iovec(thread_array);
+    let pid = rros_get_inband_pid(thread as *const RrosThread);
+    let info = thread.info;
+
+    unsafe{
+        rust_helper_trace_rros_wakeup_thread(thread_iov, pid as u32, mask as i32, info as i32);
+    }
+}
+pub fn trace_rros_hold_thread(thread: &RrosThread, mask: u32){
+    extern "C"{
+        fn rust_helper_trace_rros_hold_thread(thread_name:bindings::iovec,pid:u32,mask:u64);
+    }
+    let pid = rros_get_inband_pid(thread as *const RrosThread);
+    let thread_array = thread.name.as_bytes();
+    let thread_iovec = slice_to_iovec(thread_array);
+    unsafe{
+        rust_helper_trace_rros_hold_thread(thread_iovec, pid as u32, mask as u64);
+    }
+}
+pub fn trace_rros_release_thread(thread: &RrosThread, mask: u32, info: u32){
+    extern "C"{
+        fn rust_helper_trace_rros_release_thread(thread_name:bindings::iovec,pid:u32,mask:i32,info:i32);
+    }
+    let pid = rros_get_inband_pid(thread as *const RrosThread);
+    let thread_array = thread.name.as_bytes();
+    let thread_iovec = slice_to_iovec(thread_array);
+    unsafe{
+        rust_helper_trace_rros_release_thread(thread_iovec,pid as u32, mask as i32, info as i32);
+    }
+}
+pub fn trace_rros_thread_set_current_prio(thread: &RrosThread){
+    extern "C"{
+        fn rust_helper_trace_rros_thread_set_current_prio(thread:*mut c_void,pid:u32,cprio:i32);
+    }
+    let pid = rros_get_inband_pid(thread as *const RrosThread);
+    let cprio = thread.cprio;
+    unsafe{
+        rust_helper_trace_rros_thread_set_current_prio(thread as *const _ as *mut c_void, pid as u32, cprio);
+    }
+}
+pub fn trace_rros_thread_cancel(thread: &RrosThread){
+    extern "C"{
+        fn rust_helper_trace_rros_thread_cancel(pid:u32,state:u32,info:u32);
+    }
+    let pid = rros_get_inband_pid(thread as *const RrosThread);
+    let state = thread.state;
+    let info = thread.info;
+    unsafe{
+        rust_helper_trace_rros_thread_cancel(pid as u32, state, info);
+    }
+}
+//TODO: rros_join_thread is not impl.
+pub fn trace_rros_thread_join(thread: &RrosThread){
+    extern "C"{
+        fn rust_helper_trace_rros_thread_join(pid:i32, state:u32, info:u32);
+    }
+    let pid = rros_get_inband_pid(thread as *const RrosThread);
+    let state = thread.state;
+    let info = thread.info;
+    unsafe{
+        rust_helper_trace_rros_thread_join(pid, state, info);
+    }
+}
+//TODO: rros_unblock_thread is not impl.
+pub fn trace_rros_unblock_thread(thread: &RrosThread){
+    extern "C"{
+        fn rust_helper_trace_rros_unblock_thread(pid:i32, state:u32, info:u32);
+    }
+    let pid = rros_get_inband_pid(thread as *const RrosThread);
+    let state = thread.state;
+    let info = thread.info;
+    unsafe{
+        rust_helper_trace_rros_unblock_thread(pid, state, info);
+    }
+}
+pub fn trace_rros_thread_wait_period(thread: &RrosThread){
+    extern "C"{
+        fn rust_helper_trace_rros_thread_wait_period(state:u32,info:u32);
+    }
+    let state = thread.state;
+    let info = thread.info;
+    unsafe{
+        rust_helper_trace_rros_thread_wait_period(state, info);
+    }
+}
+pub fn trace_rros_thread_missed_period(thread: &RrosThread){
+    extern "C"{
+        fn rust_helper_trace_rros_thread_missed_period(state:u32,info:u32);
+    }
+    let state = thread.state;
+    let info = thread.info;
+    unsafe{
+        rust_helper_trace_rros_thread_missed_period(state, info);
+    }
+}
+// TODO: func rros_migrate_thread is not impl.
+pub fn trace_rros_thread_migrate(thread: &RrosThread, cpu: u32){
+    extern "C"{
+        fn rust_helper_trace_rros_thread_migrate(thread:*mut c_void,pid:u32,cpu:u32);
+    }
+    let pid = rros_get_inband_pid(thread as *const RrosThread);
+    unsafe{
+        rust_helper_trace_rros_thread_migrate(thread as *const _ as *mut c_void,pid as u32,cpu);
+    }
+}
+pub fn trace_rros_watchdog_signal(thread: &RrosThread){
+    extern "C"{
+        fn rust_helper_trace_rros_watchdog_signal(state:u32,info:u32);
+    }
+    let state = thread.state;
+    let info = thread.info;
+    unsafe{
+        rust_helper_trace_rros_watchdog_signal(state, info);
+    }
+}
+pub fn trace_rros_switch_oob(thread: &RrosThread){
+    extern "C"{
+        fn rust_helper_trace_rros_switch_oob(state:u32,info:u32);
+    }
+    let state = thread.state;
+    let info = thread.info;
+    unsafe{
+        rust_helper_trace_rros_switch_oob(state, info);
+    }
+}
+pub fn trace_rros_switched_oob(thread: &RrosThread){
+    extern "C"{
+        fn rust_helper_trace_rros_switched_oob(state:u32,info:u32);
+    }
+    let state = thread.state;
+    let info = thread.info;
+    unsafe{
+        rust_helper_trace_rros_switched_oob(state, info);
+    }
+}
+pub fn trace_rros_switch_inband(cause: i32){
+    extern "C"{
+        fn rust_helper_trace_rros_switch_inband(cause:i32);
+    }
+    unsafe{
+        rust_helper_trace_rros_switch_inband(cause);
+    }
+}
+pub fn trace_rros_switched_inband(thread: &RrosThread){
+    extern "C"{
+        fn rust_helper_trace_rros_switched_inband(state:u32,info:u32);
+    }
+    let state = thread.state;
+    let info = thread.info;
+    unsafe{
+        rust_helper_trace_rros_switched_inband(state, info);
+    }
+}
+pub fn trace_rros_kthread_entry(thread: &RrosThread){
+    extern "C"{
+        fn rust_helper_trace_rros_kthread_entry(state:u32,info:u32);
+    }
+    let state = thread.state;
+    let info = thread.info;
+    unsafe{
+        rust_helper_trace_rros_kthread_entry(state, info);
+    }
+}
+pub fn trace_rros_thread_map(thread: &RrosThread){
+    extern "C"{
+        fn rust_helper_trace_rros_thread_map(thread:*mut c_void,pid:u32,prio:i32);
+    }
+    let pid = rros_get_inband_pid(thread as *const RrosThread);
+    let prio = thread.bprio;
+    unsafe{
+        rust_helper_trace_rros_thread_map(thread as *const _ as *mut c_void, pid as u32, prio);
+    }
+}
+pub fn trace_rros_thread_unmap(thread: &RrosThread){
+    extern "C"{
+        fn rust_helper_trace_rros_thread_unmap(state:u32,info:u32);
+    }
+    let state = thread.state;
+    let info = thread.info;
+    unsafe{
+        rust_helper_trace_rros_thread_unmap(state, info);
+    }
+}
+pub fn trace_rros_inband_wakeup(thread: *const RrosThread){
+    extern "C"{
+        fn rust_helper_trace_rros_inband_wakeup(pid:u32,comm:bindings::iovec);
+    }
+    unsafe{
+        let task = (*thread).altsched.0.task;
+        let pid = (*task).pid;
+        let comm_array = (*task).comm;
+        let comm = bindings::iovec {
+            iov_base: comm_array.as_ptr() as *const _ as *mut c_void,
+            iov_len: comm_array.len() as u64
+        };
+        rust_helper_trace_rros_inband_wakeup(pid as u32, comm);
+    }
+}
+// TODO: func do_inband_signal is not impl.
+// pub fn trace_rros_inband_signal(){
+//     extern "C"{
+//         fn rust_helper_trace_rros_inband_signal(element_name:bindings::iovec,pid:u32,sig:i32,sigval:i32);
+//     }
+//     unsafe{
+//         rust_helper_trace_rros_inband_signal(element_name,pid,sig,sigval);
+//     }
+// }
+// NOTE: `__rros_stop_timer` seems incorrect.
+pub fn trace_rros_timer_stop(timer: &RrosTimer){
+    extern "C"{
+        fn rust_helper_trace_rros_timer_stop(name:bindings::iovec);
+    }
+    let name_array = timer.get_name().as_bytes();
+    let name_iov = slice_to_iovec(name_array);
+    unsafe{
+        rust_helper_trace_rros_timer_stop(name_iov);
+    }
+}
+pub fn trace_rros_timer_expire(timer: &RrosTimer){
+    extern "C"{
+        fn rust_helper_trace_rros_timer_expire(name:bindings::iovec);
+    }
+    let name_array = timer.get_name().as_bytes();
+    let name_iov = slice_to_iovec(name_array);
+    unsafe{
+        rust_helper_trace_rros_timer_expire(name_iov);
+    }
+}
+pub fn trace_rros_timer_start(timer: &RrosTimer, value: ktime::KtimeT, interval: ktime::KtimeT){
+    extern "C"{
+        fn rust_helper_trace_rros_timer_start(timer_name:bindings::iovec,value:bindings::ktime_t,interval:bindings::ktime_t);
+    }
+    let name_array = timer.get_name().as_bytes();
+    let name_iov = slice_to_iovec(name_array);
+    unsafe{
+        rust_helper_trace_rros_timer_start(name_iov, value, interval);
+    }
+}
+// TODO: func rros_move_tiemr is not impl.
+// pub fn trace_rros_timer_move(timer: &RrosTimer, ){
+//     extern "C"{
+//         fn rust_helper_trace_rros_timer_move(timer_name:bindings::iovec,clock_name:bindings::iovec,cpu:u32);
+//     }
+//     unsafe{
+//         rust_helper_trace_rros_timer_move(timer_name,clock_name,cpu);
+//     }
+// }
+pub fn trace_rros_timer_shot(timer: &RrosTimer, delta: i64, cycles: i64){
+    extern "C"{
+        fn rust_helper_trace_rros_timer_shot(timer_name:bindings::iovec,delta:i64,cycles:u64);
+    }
+    let name_array = timer.get_name().as_bytes();
+    let name_iov = slice_to_iovec(name_array);
+    unsafe{
+        rust_helper_trace_rros_timer_shot(name_iov, delta, cycles as u64);
+    }
+}
+// NOTE: trace in `RrosWaitQueue.locked_add`
+// FIXME: wq.wchan(RrosWaitChannel) doesn't have the filed named `name`
+// pub fn trace_rros_wait(wq: &RrosWaitQueue){
+//     extern "C"{
+//         fn rust_helper_trace_rros_wait(name:bindings::iovec);
+//     }
+//     unsafe{
+//         rust_helper_trace_rros_wait(name);
+//     }
+// }
+// NOTE: trace in `RrosWaitQueue.wake_up`
+// FIXME: wq.wchan(RrosWaitChannel) doesn't have the filed named `name`
+// pub fn trace_rros_wake_up(wq: &RrosWaitQueue){
+//     extern "C"{
+//         fn rust_helper_trace_rros_wake_up(name:bindings::iovec);
+//     }
+//     unsafe{
+//         rust_helper_trace_rros_wake_up(name);
+//     }
+// }
+// NOTE: trace in `RrosWaitQueue.flush_locked`
+// FIXME: wq.wchan(RrosWaitChannel) doesn't have the filed named `name`
+// pub fn trace_rros_flush_wait(wq: &RrosWaitQueue){
+//     extern "C"{
+//         fn rust_helper_trace_rros_flush_wait(name:bindings::iovec);
+//     }
+//     unsafe{
+//         rust_helper_trace_rros_flush_wait(name);
+//     }
+// }
+// NOTE: trace in `RrosWaitQueue.wait_schedule`
+// FIXME: wq.wchan(RrosWaitChannel) doesn't have the filed named `name`
+// pub fn trace_rros_finish_wait(wq: &RrosWaitQueue){
+//     extern "C"{
+//         fn rust_helper_trace_rros_finish_wait(name:bindings::iovec);
+//     }
+//     unsafe{
+//         rust_helper_trace_rros_finish_wait(name);
+//     }
+// }
+pub fn trace_rros_oob_sysentry(nr: u32){
+    extern "C"{
+        fn rust_helper_trace_rros_oob_sysentry(nr:u32);
+    }
+    unsafe{
+        rust_helper_trace_rros_oob_sysentry(nr);
+    }
+}
+pub fn trace_rros_oob_sysexit(result: i64){
+    extern "C"{
+        fn rust_helper_trace_rros_oob_sysexit(result:i64);
+    }
+    unsafe{
+        rust_helper_trace_rros_oob_sysexit(result);
+    }
+}
+pub fn trace_rros_inband_sysentry(nr: u32){
+    extern "C"{
+        fn rust_helper_trace_rros_inband_sysentry(nr:u32);
+    }
+    unsafe{
+        rust_helper_trace_rros_inband_sysentry(nr);
+    }
+}
+pub fn trace_rros_inband_sysexit(result: i64){
+    extern "C"{
+        fn rust_helper_trace_rros_inband_sysexit(result:i64);
+    }
+    unsafe{
+        rust_helper_trace_rros_inband_sysexit(result);
+    }
+}
+// TODO: func update_mode is not impl
+// pub fn trace_rros_thread_update_mode(thread: &RrosThread, mode: i32, set: bool){
+//     extern "C"{
+//         fn rust_helper_trace_rros_thread_update_mode(element_name:bindings::iovec,mode:i32,set:bool);
+//     }
+//     unsafe{
+//         rust_helper_trace_rros_thread_update_mode(element_name,mode,set);
+//     }
+// }
+// TODO: func get_clock_resoition is not impl.
+// pub fn trace_rros_clock_getres(){
+//     extern "C"{
+//         fn rust_helper_trace_rros_clock_getres(clock_name:bindings::iovec,val:*const bindings::timespec64);
+//     }
+//     unsafe{
+//         rust_helper_trace_rros_clock_getres(clock_name,val);
+//     }
+// }
+// TODO: func get_clock_time is not impl.
+// pub fn trace_rros_clock_gettime(){
+//     extern "C"{
+//         fn rust_helper_trace_rros_clock_gettime(clock_name:bindings::iovec,val:*const bindings::timespec64);
+//     }
+//     unsafe{
+//         rust_helper_trace_rros_clock_gettime(clock_name,val);
+//     }
+// }
+// TODO: func set_clock_time is not impl.
+// pub fn trace_rros_clock_settime(){
+//     extern "C"{
+//         fn rust_helper_trace_rros_clock_settime(clock_name:bindings::iovec,val:*const bindings::timespec64);
+//     }
+//     unsafe{
+//         rust_helper_trace_rros_clock_settime(clock_name,val);
+//     }
+// }
+// pub fn trace_rros_clock_adjtime(){
+//     extern "C"{
+//         fn rust_helper_trace_rros_clock_adjtime(clock_name:bindings::iovec,tx:TODO:struct __kernel_timex *);
+//     }
+//     unsafe{
+//         rust_helper_trace_rros_clock_adjtime(clock_name,tx);
+//     }
+// }
+// TODO: func rros_register_clock is not impl.
+// pub fn trace_rros_register_clock(){
+//     extern "C"{
+//         fn rust_helper_trace_rros_register_clock(name:bindings::iovec);
+//     }
+//     unsafe{
+//         rust_helper_trace_rros_register_clock(name);
+//     }
+// }
+// TODO: func rros_unregister_clock is not impl.
+// pub fn trace_rros_unregister_clock(){
+//     extern "C"{
+//         fn rust_helper_trace_rros_unregister_clock(name:bindings::iovec);
+//     }
+//     unsafe{
+//         rust_helper_trace_rros_unregister_clock(name);
+//     }
+// }
+pub fn trace_rros_trace(msg: &[u8]){
+    extern "C"{
+        fn rust_helper_trace_rros_trace(msg:bindings::iovec);
+    }
+    let msg_iov = slice_to_iovec(msg);
+    unsafe{
+        rust_helper_trace_rros_trace(msg_iov);
+    }
+}


### PR DESCRIPTION
The Linux kernel provides tools for profiling, such as TRACE_EVENT, kprobe, ftrace, and perf. I have implemented some tracepoints for the RROS system in C, utilizing the TRACE_EVENT provided by Linux, and added them to the export symbol table for use in Rust code within the RROS system.

https://github.com/BUPT-OS/RROS/issues/30