### PR TITLE
rros: stax: add stax and corresponding driver to test

### DIFF
--- a/kernel/rros/drivers/hectic.rs
+++ b/kernel/rros/drivers/hectic.rs
@@ -1,0 +1,245 @@
+use core::result::Result::Err;
+
+use alloc::sync::{Arc, Weak};
+
+use crate::{
+    file::{rros_open_file, rros_release_file, RrosFile},
+    flags::RrosFlag,
+    guard::Guard,
+    stax::Stax,
+    thread::RrosKthread,
+    timer::*,
+};
+
+use kernel::{
+    c_str, chrdev, file_operations, irq_work::IrqWork, prelude::*, spinlock_init, sync::SpinLock,
+    KernelModule,
+};
+
+const RROS_HECIOC_LOCK_STAX: u32 = 18441;
+const RROS_HECIOC_UNLOCK_STAX: u32 = 18442;
+
+module! {
+    type: Hecticdev,
+    name: b"hectic",
+    author: b"wxg",
+    description: b"hectic driver",
+    license: b"GPL v2",
+}
+
+#[repr(C)]
+struct HecticTaskIndex {
+    index: u32,
+    flags: u32,
+}
+
+#[repr(C)]
+struct HecticSwitchReq {
+    from: u32,
+    to: u32,
+}
+
+#[allow(dead_code)]
+struct HecticError {
+    last_switch: HecticSwitchReq,
+    fp_val: u32,
+}
+
+#[allow(dead_code)]
+struct RtswitchTask {
+    base: HecticTaskIndex,
+    rt_synch: RrosFlag,
+    //TODO: nrt_synch: semaphore
+    kthread: RrosKthread,
+    last_switch: u32,
+    ctx: Option<Weak<RtswitchTask>>,
+}
+
+#[allow(dead_code)]
+pub struct RtswitchContext {
+    tasks: Vec<Arc<RtswitchTask>>,
+    tasks_count: u32,
+    next_index: u32,
+    //lock: Semaphore,
+    cpu: u32,
+    switches_count: u32,
+    pause_us: u64,
+    next_task: u32,
+    wake_up_delay: Arc<SpinLock<RrosTimer>>,
+    failed: bool,
+    error: HecticError,
+    utask: Option<Weak<RtswitchTask>>,
+    wake_utask: IrqWork,
+    stax: Pin<Box<Stax<()>>>,
+    o_guard: SpinLock<Vec<usize>>,
+    i_guard: SpinLock<Vec<usize>>,
+    rfile: RrosFile,
+}
+
+impl RtswitchTask {
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Self {
+            base: HecticTaskIndex { index: 0, flags: 0 },
+            rt_synch: RrosFlag::new(),
+            kthread: RrosKthread::new(None),
+            last_switch: 0,
+            ctx: None,
+        }
+    }
+}
+
+impl RtswitchContext {
+    fn new() -> Result<Self> {
+        // Spinlock and Stax have to be initialized after new.So their new function is unsafe.
+        // Safety: We promise that the SpinLock and Stax will be initialized before they are used.
+        let ctx = RtswitchContext {
+            tasks: Vec::new(),
+            tasks_count: 0,
+            next_index: 0,
+            //lock: Semaphore::new(),
+            cpu: 0,
+            switches_count: 0,
+            pause_us: 0,
+            next_task: 0,
+            wake_up_delay: Arc::try_new(unsafe { SpinLock::new(RrosTimer::new(0)) })?,
+            failed: false,
+            error: HecticError {
+                last_switch: HecticSwitchReq {
+                    from: u32::MAX,
+                    to: u32::MAX,
+                },
+                fp_val: 0,
+            },
+            utask: None,
+            wake_utask: IrqWork::new(),
+            stax: unsafe { Pin::from(Box::try_new(Stax::new(()))?) },
+            o_guard: unsafe { SpinLock::new(Vec::new()) },
+            i_guard: unsafe { SpinLock::new(Vec::new()) },
+            rfile: RrosFile::new(),
+        };
+        Ok(ctx)
+    }
+
+    fn init(&mut self) -> Result<()> {
+        Stax::init((&mut self.stax).as_mut())?;
+        let o_pinned = unsafe { Pin::new_unchecked(&mut self.o_guard) };
+        spinlock_init!(o_pinned, "o_guard");
+        let i_pinned = unsafe { Pin::new_unchecked(&mut self.i_guard) };
+        spinlock_init!(i_pinned, "i_guard");
+        // TODO: some initialization which is not needed by stax test
+        return Ok(());
+    }
+}
+pub struct HecticFile;
+
+impl file_operations::FileOpener<u8> for HecticFile {
+    fn open(_context: &u8, file: &kernel::file::File) -> kernel::Result<Self::Wrapper> {
+        let mut ctx: Box<RtswitchContext> = Box::try_new(RtswitchContext::new()?)?;
+        let ctx_ref = ctx.as_mut();
+        ctx_ref.init()?;
+        let rfile = &mut ctx_ref.rfile;
+        rros_open_file(rfile, file.get_ptr())?;
+        Ok(ctx)
+    }
+}
+
+fn lock_stax(ctx: &RtswitchContext, is_inband: bool) -> Result<i32> {
+    match ctx.stax.as_ref().get_ref().lock() {
+        Ok(g) => {
+            let tmp = Box::try_new(g)?;
+            let mut guard = if is_inband {
+                ctx.i_guard.lock()
+            } else {
+                ctx.o_guard.lock()
+            };
+            guard.try_push(Box::into_raw(tmp) as usize)?;
+            Ok(0)
+        }
+        Err(e) => {
+            return Err(e);
+        }
+    }
+}
+
+fn unlock_stax(ctx: &RtswitchContext, is_inband: bool) -> Result<i32> {
+    let tmp;
+    let mut count = 0;
+    loop {
+        count += 1;
+        let mut guard = if is_inband {
+            ctx.i_guard.lock()
+        } else {
+            ctx.o_guard.lock()
+        };
+        if let Some(t) = guard.pop() {
+            tmp = t;
+            break;
+        }
+        if count > 1000 {
+            return Ok(0);
+        }
+    }
+    // Safety: Every pointer will be pushed and poped in a pair. And the pointer is vaild before it is poped.
+    unsafe {
+        Box::from_raw(tmp as *mut Guard<'_, Stax<()>>);
+    }
+    Ok(0)
+}
+
+impl file_operations::FileOperations for HecticFile {
+    kernel::declare_file_operations!(ioctl, oob_ioctl, compat_ioctl, compat_oob_ioctl);
+
+    type Wrapper = Box<RtswitchContext>;
+
+    fn release(mut ctx: Self::Wrapper, _file: &kernel::file::File) {
+        rros_release_file(&mut ctx.rfile).expect("release file failed");
+        pr_debug!("hectic release!\n");
+    }
+
+    fn ioctl(
+        ctx: &<<Self::Wrapper as kernel::types::PointerWrapper>::Borrowed as core::ops::Deref>::Target,
+        _file: &kernel::file::File,
+        cmd: &mut file_operations::IoctlCommand,
+    ) -> kernel::Result<i32> {
+        pr_debug!("Hectic ioctl\n");
+        match cmd.cmd {
+            RROS_HECIOC_LOCK_STAX => lock_stax(ctx, true),
+            RROS_HECIOC_UNLOCK_STAX => unlock_stax(ctx, true),
+            _ => Ok(0),
+        }
+    }
+
+    fn oob_ioctl(
+        ctx: &<<Self::Wrapper as kernel::types::PointerWrapper>::Borrowed as core::ops::Deref>::Target,
+        _file: &kernel::file::File,
+        cmd: &mut file_operations::IoctlCommand,
+    ) -> kernel::Result<i32> {
+        pr_debug!("Hectic oob_ioctl\n");
+        match cmd.cmd {
+            RROS_HECIOC_LOCK_STAX => lock_stax(ctx, false),
+            RROS_HECIOC_UNLOCK_STAX => unlock_stax(ctx, false),
+            _ => Ok(0),
+        }
+    }
+}
+
+pub struct Hecticdev {
+    pub dev: Pin<Box<chrdev::Registration<1>>>,
+}
+
+impl KernelModule for Hecticdev {
+    fn init() -> Result<Self> {
+        let mut _dev = chrdev::Registration::new_pinned(c_str!("hecticdev"), 0, &THIS_MODULE)?;
+
+        _dev.as_mut().register::<HecticFile>()?;
+
+        Ok(Hecticdev { dev: _dev })
+    }
+}
+
+impl Drop for Hecticdev {
+    fn drop(&mut self) {
+        pr_debug!("Hectic exit\n");
+    }
+}

--- a/kernel/rros/drivers/mod.rs
+++ b/kernel/rros/drivers/mod.rs
@@ -1,0 +1,1 @@
+pub mod hectic;

--- a/kernel/rros/guard.rs
+++ b/kernel/rros/guard.rs
@@ -1,0 +1,78 @@
+// To be removed once updated to the latest version of the Liunx.
+use kernel::error::Result;
+
+/// Allows mutual exclusion primitives that implement the [`RrosLock`] trait to automatically unlock
+/// when a guard goes out of scope. It also provides a safe and convenient way to access the data
+/// protected by the lock.
+pub struct Guard<'a, L: RrosLock + ?Sized> {
+    pub(crate) lock: &'a L,
+}
+
+// SAFETY: `Guard` is sync when the data protected by the lock is also sync. This is more
+// conservative than the default compiler implementation; more details can be found on
+// https://github.com/rust-lang/rust/issues/41622 -- it refers to `MutexGuard` from the standard
+// library.
+unsafe impl<L> Sync for Guard<'_, L>
+where
+    L: RrosLock + ?Sized,
+    L::Inner: Sync,
+{
+}
+
+impl<L: RrosLock + ?Sized> core::ops::Deref for Guard<'_, L> {
+    type Target = L::Inner;
+
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: The caller owns the lock, so it is safe to deref the protected data.
+        unsafe { &*self.lock.locked_data().get() }
+    }
+}
+
+impl<L: RrosLock + ?Sized> core::ops::DerefMut for Guard<'_, L> {
+    fn deref_mut(&mut self) -> &mut L::Inner {
+        // SAFETY: The caller owns the lock, so it is safe to deref the protected data.
+        unsafe { &mut *self.lock.locked_data().get() }
+    }
+}
+
+impl<L: RrosLock + ?Sized> Drop for Guard<'_, L> {
+    fn drop(&mut self) {
+        // SAFETY: The caller owns the lock, so it is safe to unlock it.
+        unsafe { self.lock.unlock() };
+    }
+}
+
+impl<'a, L: RrosLock + ?Sized> Guard<'a, L> {
+    /// Constructs a new lock guard.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that it owns the lock.
+    pub unsafe fn new(lock: &'a L) -> Self {
+        Self { lock }
+    }
+}
+
+/// A generic mutual exclusion primitive.
+///
+/// [`Guard`] is written such that any mutual exclusion primitive that can implement this trait can
+/// also benefit from having an automatic way to unlock itself.
+pub trait RrosLock {
+    /// The type of the data protected by the lock.
+    type Inner: ?Sized;
+
+    /// Acquires the lock, making the caller its owner.
+    fn lock_noguard(&self) -> Result<()>;
+
+    /// Try to cquires the lock, making the caller its owner.
+    fn try_lock_noguard(&self) -> Result<()>;
+    /// Releases the lock, giving up ownership of the lock.
+    ///
+    /// # Safety
+    ///
+    /// It must only be called by the current owner of the lock.
+    unsafe fn unlock(&self);
+
+    /// Returns the data protected by the lock.
+    fn locked_data(&self) -> &core::cell::UnsafeCell<Self::Inner>;
+}

--- a/kernel/rros/init.rs
+++ b/kernel/rros/init.rs
@@ -47,7 +47,9 @@ mod memory;
 mod memory_test;
 mod monitor;
 // mod mutex;
+mod guard;
 mod sched_test;
+mod stax;
 mod syscall;
 mod thread_test;
 mod timer;
@@ -79,6 +81,7 @@ mod xbuf;
 #[cfg(CONFIG_NET)]
 mod net;
 
+mod drivers;
 // pub use net::netif_oob_switch_port;
 
 module! {

--- a/kernel/rros/stax.rs
+++ b/kernel/rros/stax.rs
@@ -1,0 +1,626 @@
+use core::{
+    cell::UnsafeCell,
+    marker::PhantomPinned,
+    ops::DerefMut,
+    sync::atomic::{AtomicU32, Ordering},
+};
+
+use crate::{
+    clock::{RrosClock, RROS_MONO_CLOCK},
+    guard::{Guard, RrosLock},
+    sched::{rros_schedule, RrosThread, RrosValue},
+    thread::{rros_current, rros_kick_thread, rros_notify_thread, RROS_HMDIAG_STAGEX, T_WOSX},
+    timeout::{RrosTmode::RrosRel, RROS_INFINITE},
+    wait::{RrosWaitQueue, RROS_WAIT_PRIO},
+};
+
+use kernel::{
+    bindings,
+    c_types::c_void,
+    error::Result,
+    irq_work::IrqWork,
+    prelude::*,
+    premmpt::running_inband,
+    sched::{schedule, set_current_state},
+    sync::SpinLock,
+    task::Task,
+    waitqueue::{WaitQueueEntry, WaitQueueHead},
+};
+
+/// Gate marker for in-band activity.
+pub const STAX_INBAND_BIT: u32 = 1 << 31;
+/// The stax is being claimed by the converse stage.
+pub const STAX_CLAIMED_BIT: u32 = 1 << 30;
+/// The number of threads currently traversing the section.
+pub const STAX_CONCURRENCY_MASK: u32 = !(STAX_INBAND_BIT | STAX_CLAIMED_BIT);
+
+/// Exposes the Rros kernel's [`struct RrosStax`]. When multiple threads attempt to lock the same stax,
+/// only one stage's thread at a time is allowed to progress, the others will block (sleep) until the stax is
+/// unlocked, at which point another thread will be allowed to wake up and make progress.
+///
+/// A [`Stax`] must first be initialised with a call to [`Stax::init`] before it can be used. The
+/// [`stax_init`] macro is provided to automatically assign a new lock class to a stax instance.
+///
+/// Since it may block, [`Stax`] needs to be used with care in atomic contexts.
+///
+/// [`struct RrosStax`]: below
+pub struct Stax<T: ?Sized> {
+    /// The Rros kernel `struct RrosStax` object.
+    stax: RrosStax,
+
+    /// A Stax needs to be pinned because it contains a [`struct list_head`] that is
+    /// self-referential, so it cannot be safely moved once it is initialised.
+    _pin: PhantomPinned,
+
+    /// The data protected by the Stax.
+    data: UnsafeCell<T>,
+}
+
+// SAFETY: `Stax` can be transferred across thread boundaries if the data it protects can.
+unsafe impl<T: ?Sized + Send> Send for Stax<T> {}
+
+// SAFETY: `Stax` serialises the interior mutability it provides, more than one thread can access the data
+// so it is `Sync` as long as the data it protects is `Sync`.
+unsafe impl<T: ?Sized + Send + Sync> Sync for Stax<T> {}
+
+impl<T> Stax<T> {
+    /// Constructs a new stax.
+    ///
+    /// # Safety
+    ///
+    /// The caller must call [`Stax::init`] before using the stax.
+    #[warn(dead_code)]
+    pub unsafe fn new(t: T) -> Self {
+        Self {
+            stax: unsafe { RrosStax::new() },
+            data: UnsafeCell::new(t),
+            _pin: PhantomPinned,
+        }
+    }
+
+    /// Initialize the stax.
+    #[warn(dead_code)]
+    pub fn init(self: Pin<&mut Self>) -> Result<()> {
+        // SAFETY: Initializing the stax will not move the data out of the mutable reference.
+        unsafe { self.get_unchecked_mut().stax.init() }
+    }
+}
+
+impl<T: ?Sized> Stax<T> {
+    /// Locks the stax and gives the caller access to the data protected by it. Only threads of one stage at
+    /// a time is allowed to access the protected data.
+    #[warn(dead_code)]
+    pub fn lock(&self) -> Result<Guard<'_, Self>> {
+        self.lock_noguard()?;
+        // SAFETY: The stax was just acquired.
+        unsafe { Ok(Guard::new(self)) }
+    }
+
+    /// Try to lock the stax and gives the caller access to the data protected by it. Only threads of one stage at
+    /// a time is allowed to access the protected data.If the stax is already locked, a value is returned immediately.
+    #[allow(dead_code)]
+    pub fn try_lock(&self) -> Result<Guard<'_, Self>> {
+        self.try_lock_noguard()?;
+        // SAFETY: The stax was just acquired.
+        unsafe { Ok(Guard::new(self)) }
+    }
+}
+
+impl<T: ?Sized> RrosLock for Stax<T> {
+    type Inner = T;
+
+    fn lock_noguard(&self) -> Result<()> {
+        // SAFETY: `stax` points to valid memory.
+        let tmp = unsafe { &mut *(&self.stax as *const RrosStax as *mut RrosStax) };
+        tmp.lock()
+    }
+
+    fn try_lock_noguard(&self) -> Result<()> {
+        // SAFETY: `stax` points to valid memory.
+        let tmp = unsafe { &mut *(&self.stax as *const RrosStax as *mut RrosStax) };
+        tmp.try_lock()
+    }
+
+    unsafe fn unlock(&self) {
+        // SAFETY: `stax` points to valid memory.
+        let tmp = unsafe { &mut *(&self.stax as *const RrosStax as *mut RrosStax) };
+        tmp.unlock();
+    }
+
+    fn locked_data(&self) -> &UnsafeCell<T> {
+        &self.data
+    }
+}
+
+impl<T: ?Sized> Drop for Stax<T> {
+    fn drop(&mut self) {
+        self.stax.destory();
+    }
+}
+/// A lock used to block access to a resource by both in-band and out-of-band threads
+/// A thread of one stage can acquire a lock
+/// only after all threads of the converse stage have released the lock
+struct RrosStax {
+    gate: AtomicU32,
+    oob_wait: RrosWaitQueue,
+    inband_wait: WaitQueueHead,
+    irq_work: IrqWork,
+    _pin: PhantomPinned,
+}
+
+impl RrosStax {
+    /// Create a new RrosStax.
+    // Safety: The caller must ensure that the returned struct is initialised before use.
+    #[allow(dead_code)]
+    unsafe fn new() -> Self {
+        let stax: RrosStax = RrosStax {
+            gate: AtomicU32::new(0),
+            oob_wait: unsafe {
+                RrosWaitQueue::new(
+                    &mut RROS_MONO_CLOCK as *mut RrosClock,
+                    RROS_WAIT_PRIO as i32,
+                )
+            },
+            inband_wait: WaitQueueHead::new(),
+            irq_work: IrqWork::new(),
+            _pin: PhantomPinned,
+        };
+        stax
+    }
+    /// Initialize the RrosStax.
+    #[allow(dead_code)]
+    fn init(&mut self) -> Result<()> {
+        // Safety: RROS_MONO_CLOCK is static and will not be moved.
+        self.oob_wait.init(
+            unsafe { &mut RROS_MONO_CLOCK as *mut RrosClock },
+            RROS_WAIT_PRIO as i32,
+        );
+        self.inband_wait.init();
+        self.irq_work.init_irq_work(c_wakeup_inband_waiters)?;
+        Ok(())
+    }
+    /// Destory the RrosStax.
+    #[allow(dead_code)]
+    fn destory(&mut self) {
+        self.oob_wait.destory();
+    }
+    /// Lock the RrosStax.
+    /// When a lock is held by a thread in the converse stage, the current thread is blocked.
+    #[allow(dead_code)]
+    fn lock(&mut self) -> Result<()> {
+        //TODO: EVL_WARN_ON(CORE,evl_in_irq());
+        if running_inband().is_ok() {
+            self.lock_from_inband(true)
+        } else {
+            self.lock_from_oob(true)
+        }
+    }
+    /// Try to lock the RrosStax.
+    /// When the lock is held by a thread in the converse stage, a value is returned immediately.
+    #[allow(dead_code)]
+    fn try_lock(&mut self) -> Result<()> {
+        if running_inband().is_ok() {
+            self.lock_from_inband(false)
+        } else {
+            self.lock_from_oob(false)
+        }
+    }
+    /// Unlock the RrosStax.
+    /// When the last thread of this stage releases the lock,
+    /// if there are threads of the converse stage waiting for the lock,
+    /// wakes up the threads.
+    #[allow(dead_code)]
+    fn unlock(&mut self) {
+        //TODO: EVL_WARN_ON(CORE, evl_in_irq());
+        if running_inband().is_ok() {
+            self.unlock_from_inband();
+        } else {
+            self.unlock_from_oob();
+        }
+    }
+    fn lock_from_inband(&mut self, wait: bool) -> Result<()> {
+        let mut old: u32;
+        let mut new: u32;
+
+        loop {
+            old = self.gate.load(Ordering::Acquire);
+            if (old & STAX_CONCURRENCY_MASK) != 0 {
+                old |= STAX_INBAND_BIT;
+            }
+            new = ((old & !STAX_INBAND_BIT) + 1) | STAX_INBAND_BIT;
+
+            match self
+                .gate
+                .compare_exchange(old, new, Ordering::AcqRel, Ordering::Acquire)
+            {
+                Ok(_) => break,
+                Err(prev) => {
+                    if inband_may_access(prev) {
+                        continue;
+                    }
+                    if !wait {
+                        return Err(Error::EAGAIN);
+                    }
+                    self.claim_stax_from_inband(prev)?
+                }
+            }
+        }
+
+        Ok(())
+    }
+    fn claim_stax_from_inband(&mut self, gateval: u32) -> Result<()> {
+        let mut ib_flags: u64;
+        let mut oob_flags: u64;
+        // Safety: wq_entry will be initialised immidiately.
+        let mut wq_entry = unsafe { WaitQueueEntry::new() };
+        let mut old: u32;
+        let mut new: u32;
+        let mut ret = Ok(());
+
+        wq_entry.init_wait_entry(0);
+        ib_flags = self.inband_wait.spin_lock_irqsave();
+        oob_flags = self.oob_wait.lock.raw_spin_lock_irqsave();
+
+        if (gateval & STAX_CLAIMED_BIT) != 0 {
+            old = self.gate.load(Ordering::Acquire);
+            if (old & STAX_INBAND_BIT) != 0 {
+                self.oob_wait.lock.raw_spin_unlock_irqrestore(oob_flags);
+                self.inband_wait.spin_unlock_irqrestore(ib_flags);
+                return ret;
+            }
+        } else {
+            old = gateval;
+        }
+
+        if old & STAX_CLAIMED_BIT == 0 {
+            loop {
+                new = old | STAX_CLAIMED_BIT;
+
+                match self
+                    .gate
+                    .compare_exchange_weak(old, new, Ordering::AcqRel, Ordering::Acquire)
+                {
+                    Ok(_) => break,
+                    Err(prev) => {
+                        old = prev;
+                        if (prev & STAX_INBAND_BIT) != 0 {
+                            self.oob_wait.lock.raw_spin_unlock_irqrestore(oob_flags);
+                            self.inband_wait.spin_unlock_irqrestore(ib_flags);
+                            return ret;
+                        }
+                        if (prev & STAX_CLAIMED_BIT) != 0 {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        loop {
+            if wq_entry.list_empty() {
+                self.inband_wait.add_wait_queue(&mut wq_entry);
+            }
+            if inband_may_access(self.gate.load(Ordering::Acquire)) {
+                break;
+            }
+            //TODO: wrap the constant from bindings
+            set_current_state(bindings::TASK_UNINTERRUPTIBLE as i64);
+            self.oob_wait.lock.raw_spin_unlock_irqrestore(oob_flags);
+            self.inband_wait.spin_unlock_irqrestore(ib_flags);
+            schedule();
+            ib_flags = self.inband_wait.spin_lock_irqsave();
+            oob_flags = self.oob_wait.lock.raw_spin_lock_irqsave();
+
+            if Task::current().signal_pending() {
+                ret = Err(Error::ERESTARTSYS);
+                break;
+            }
+        }
+
+        wq_entry.list_del();
+
+        if !self.inband_wait.waitqueue_active() {
+            old = self.gate.load(Ordering::Acquire);
+            loop {
+                if let Err(prev) = self.gate.compare_exchange_weak(
+                    old,
+                    old & !STAX_CLAIMED_BIT,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) {
+                    old = prev;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        self.oob_wait.lock.raw_spin_unlock_irqrestore(oob_flags);
+        self.inband_wait.spin_unlock_irqrestore(ib_flags);
+
+        ret
+    }
+    fn lock_from_oob(&mut self, wait: bool) -> Result<()> {
+        let mut old: u32;
+
+        loop {
+            old = self.gate.load(Ordering::Acquire) & !STAX_INBAND_BIT;
+
+            match self
+                .gate
+                .compare_exchange(old, old + 1, Ordering::AcqRel, Ordering::Acquire)
+            {
+                Ok(_) => break,
+                Err(prev) => {
+                    if oob_may_access(prev) {
+                        continue;
+                    }
+                    if !wait {
+                        return Err(Error::EAGAIN);
+                    }
+                    self.claim_stax_from_oob(prev)?
+                }
+            }
+        }
+
+        Ok(())
+    }
+    fn claim_stax_from_oob(&mut self, gateval: u32) -> Result<()> {
+        let ptr = rros_current();
+        let curr: Arc<SpinLock<RrosThread>>;
+        // Safety: rros_current() guarantees that the ptr is valid.
+        unsafe {
+            curr = Arc::from_raw(ptr);
+            Arc::increment_strong_count(ptr);
+        }
+        let mut old: u32;
+        let mut new: u32;
+        let mut ret = Ok(());
+        let mut flags: u64;
+        let mut notify: bool = false;
+
+        flags = self.oob_wait.lock.raw_spin_lock_irqsave();
+
+        if (gateval & STAX_CLAIMED_BIT) != 0 {
+            old = self.gate.load(Ordering::Acquire);
+            if (old & STAX_INBAND_BIT) == 0 {
+                self.oob_wait.lock.raw_spin_unlock_irqrestore(flags);
+
+                if notify {
+                    let c_t = curr.as_ref().lock().deref_mut() as *mut RrosThread;
+                    rros_notify_thread(c_t, RROS_HMDIAG_STAGEX, RrosValue::new())?;
+                    rros_kick_thread(curr, 0);
+                }
+                return ret;
+            }
+        } else {
+            old = gateval;
+        }
+
+        if old & STAX_CLAIMED_BIT == 0 {
+            loop {
+                new = old | STAX_CLAIMED_BIT;
+
+                match self
+                    .gate
+                    .compare_exchange_weak(old, new, Ordering::AcqRel, Ordering::Acquire)
+                {
+                    Ok(_) => break,
+                    Err(prev) => {
+                        old = prev;
+                        if (prev & STAX_INBAND_BIT) == 0 {
+                            self.oob_wait.lock.raw_spin_unlock_irqrestore(flags);
+
+                            if notify {
+                                let c_t = curr.as_ref().lock().deref_mut() as *mut RrosThread;
+                                rros_notify_thread(c_t, RROS_HMDIAG_STAGEX, RrosValue::new())?;
+                                rros_kick_thread(curr, 0);
+                            }
+                            return ret;
+                        }
+                        if (prev & STAX_CLAIMED_BIT) != 0 {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (curr.lock().state & T_WOSX) != 0 {
+            notify = true;
+        }
+
+        loop {
+            if oob_may_access(self.gate.load(Ordering::Acquire)) {
+                break;
+            }
+            self.oob_wait.locked_add(RROS_INFINITE, RrosRel);
+            self.oob_wait.lock.raw_spin_unlock_irqrestore(flags);
+            //TODO: wait this method return Result
+            let res = self.oob_wait.wait_schedule();
+            flags = self.oob_wait.lock.raw_spin_lock_irqsave();
+            if res != 0 {
+                ret = Err(Error::from_kernel_errno(res));
+                break;
+            }
+        }
+
+        if !self.oob_wait.is_active() {
+            old = self.gate.load(Ordering::Acquire);
+            loop {
+                match self.gate.compare_exchange_weak(
+                    old,
+                    old & !STAX_CLAIMED_BIT,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => break,
+                    Err(prev) => {
+                        old = prev;
+                    }
+                }
+            }
+        }
+
+        self.oob_wait.lock.raw_spin_unlock_irqrestore(flags);
+
+        if notify {
+            let c_t = curr.as_ref().lock().deref_mut() as *mut RrosThread;
+            rros_notify_thread(c_t, RROS_HMDIAG_STAGEX, RrosValue::new())?;
+            rros_kick_thread(curr, 0);
+        }
+        ret
+    }
+    fn unlock_from_inband(&mut self) {
+        let mut old: u32;
+        let mut new: u32;
+        let flags: u64;
+
+        old = self.gate.load(Ordering::Acquire);
+
+        while (old & STAX_CLAIMED_BIT) == 0 {
+            #[cfg(CONFIG_EVL_DEBUG_CORE)]
+            if !inband_unlock_sane(old) {
+                pr_debug!("stax: unlock from inband with invalid mask: {}\n", old);
+                return;
+            }
+            old &= !STAX_CLAIMED_BIT;
+            new = (old & !STAX_INBAND_BIT) - 1;
+            if (new & STAX_CONCURRENCY_MASK) != 0 {
+                new |= STAX_INBAND_BIT;
+            }
+
+            match self
+                .gate
+                .compare_exchange_weak(old, new, Ordering::AcqRel, Ordering::Acquire)
+            {
+                Ok(_) => return,
+                Err(prev) => {
+                    old = prev;
+                }
+            }
+        }
+
+        flags = self.oob_wait.lock.raw_spin_lock_irqsave();
+
+        loop {
+            #[cfg(CONFIG_EVL_DEBUG_CORE)]
+            if !inband_unlock_sane(old) {
+                pr_debug!("stax: unlock from inband with invalid mask: {}\n", old);
+                self.oob_wait.lock.raw_spin_unlock_irqrestore(flags);
+                return unsafe { rros_schedule() };
+            }
+            new = (old & !STAX_INBAND_BIT) - 1;
+            if (new & STAX_CONCURRENCY_MASK) != 0 {
+                new |= STAX_INBAND_BIT;
+            }
+            match self
+                .gate
+                .compare_exchange_weak(old, new, Ordering::AcqRel, Ordering::Acquire)
+            {
+                Ok(_) => break,
+                Err(prev) => {
+                    old = prev;
+                }
+            }
+        }
+
+        if (new & STAX_CONCURRENCY_MASK) == 0 {
+            self.oob_wait.flush_locked(0);
+        }
+
+        self.oob_wait.lock.raw_spin_unlock_irqrestore(flags);
+        unsafe { rros_schedule() }
+    }
+    fn unlock_from_oob(&mut self) {
+        let mut old: u32;
+        let mut new: u32;
+        let flags: u64;
+
+        old = self.gate.load(Ordering::Acquire);
+
+        while (old & STAX_CLAIMED_BIT) == 0 {
+            #[cfg(CONFIG_EVL_DEBUG_CORE)]
+            if !oob_unlock_sane(old) {
+                pr_debug!("stax: unlock from oob with invalid mask: {}\n", old);
+                return;
+            }
+            old &= !STAX_CLAIMED_BIT;
+            new = old - 1;
+            match self
+                .gate
+                .compare_exchange_weak(old, new, Ordering::AcqRel, Ordering::Acquire)
+            {
+                Ok(_) => return,
+                Err(prev) => {
+                    old = prev;
+                }
+            }
+        }
+
+        flags = self.oob_wait.lock.raw_spin_lock_irqsave();
+
+        loop {
+            new = old - 1;
+            #[cfg(CONFIG_EVL_DEBUG_CORE)]
+            if !oob_unlock_sane(old) {
+                pr_debug!("stax: unlock from oob with invalid mask: {}\n", old);
+                break;
+            }
+            match self
+                .gate
+                .compare_exchange_weak(old, new, Ordering::AcqRel, Ordering::Acquire)
+            {
+                Ok(_) => break,
+                Err(prev) => {
+                    old = prev;
+                }
+            }
+        }
+
+        self.oob_wait.lock.raw_spin_unlock_irqrestore(flags);
+
+        if (new & STAX_CONCURRENCY_MASK) == 0 {
+            match self.irq_work.irq_work_queue() {
+                Ok(_) => {}
+                Err(_) => {
+                    pr_err!("irq_work_queue failed")
+                }
+            }
+        }
+    }
+}
+
+#[inline]
+#[allow(dead_code)]
+fn inband_unlock_sane(gateval: u32) -> bool {
+    (gateval & STAX_CONCURRENCY_MASK) == 0 || (gateval & STAX_INBAND_BIT) == 0
+}
+
+#[inline]
+#[allow(dead_code)]
+fn oob_unlock_sane(gateval: u32) -> bool {
+    (gateval & STAX_CONCURRENCY_MASK) == 0 || (gateval & STAX_INBAND_BIT) != 0
+}
+
+#[inline]
+fn inband_may_access(gateval: u32) -> bool {
+    (gateval & STAX_CONCURRENCY_MASK) == 0 || (gateval & STAX_INBAND_BIT) != 0
+}
+
+#[inline]
+fn oob_may_access(gateval: u32) -> bool {
+    (gateval & STAX_INBAND_BIT) == 0
+}
+#[no_mangle]
+unsafe extern "C" fn c_wakeup_inband_waiters(work: *mut IrqWork) {
+    wakeup_inband_waiters(work);
+}
+
+#[inline]
+fn wakeup_inband_waiters(work: *mut IrqWork) {
+    // Safety: `IrqWork`'s encapsulation ensures the validity of the work pointer
+    let stax = unsafe { &mut *(kernel::container_of!(work, RrosStax, irq_work) as *mut RrosStax) };
+    stax.inband_wait
+        .wake_up(bindings::TASK_NORMAL, 0, 0 as *mut c_void);
+}

--- a/kernel/rros/xbuf.rs
+++ b/kernel/rros/xbuf.rs
@@ -210,7 +210,7 @@ pub struct XbufInbound {
 impl XbufInbound {
     pub fn new() -> Result<Self> {
         Ok(Self {
-            i_event: waitqueue::WaitQueueHead::default(),
+            i_event: waitqueue::WaitQueueHead::new(),
             o_event: RrosFlag::new(),
             irq_work: IrqWork::new(),
             ring: XbufRing::new()?,
@@ -235,7 +235,7 @@ impl XbufOutbound {
                     RROS_WAIT_PRIO as i32,
                 )
             },
-            o_event: waitqueue::WaitQueueHead::default(),
+            o_event: waitqueue::WaitQueueHead::new(),
             irq_work: IrqWork::new(),
             ring: XbufRing::new()?,
         })

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -60,12 +60,15 @@
 #include <linux/spinlock.h>
 #include <linux/spinlock_types.h>
 
+#include <linux/wait.h>
 #include <net/sock.h>
 #include <linux/jhash.h>
 #include <linux/bottom_half.h>
 #include <linux/if_vlan.h>
 #include <linux/skbuff.h>
 #include <linux/hashtable.h>
+#include <linux/kdev_t.h>
+#include <linux/sched.h>
 void rust_helper_BUG(void)
 {
 	BUG();
@@ -687,6 +690,11 @@ unsigned long rust_helper_IRQF_OOB(void) {
 }
 EXPORT_SYMBOL_GPL(rust_helper_IRQF_OOB);
 
+void rust_helper_dovetail_send_mayday(struct task_struct *castaway){
+	dovetail_send_mayday(castaway);
+}
+EXPORT_SYMBOL_GPL(rust_helper_dovetail_send_mayday);
+
 struct oob_thread_state *rust_helper_dovetail_current_state(void) {
 	return dovetail_current_state();
 }
@@ -1025,6 +1033,24 @@ void rust_helper_init_work(struct work_struct*work,void (*rust_helper_work_func)
 	INIT_WORK(work,rust_helper_work_func);
 }
 EXPORT_SYMBOL_GPL(rust_helper_init_work);
+
+//NOTE: rust_helper for stax
+unsigned long rust_helper_spin_lock_irqsave(spinlock_t *lock) {
+	unsigned long flags;
+	spin_lock_irqsave(lock, flags);
+	return flags;
+}
+EXPORT_SYMBOL_GPL(rust_helper_spin_lock_irqsave);
+
+bool rust_helper_waitqueue_active(struct wait_queue_head *wq_head) {
+	return !!waitqueue_active(wq_head);
+}
+EXPORT_SYMBOL_GPL(rust_helper_waitqueue_active);
+
+void rust_helper_init_waitqueue_head(struct wait_queue_head *wq_head) {
+	init_waitqueue_head(wq_head);
+}
+EXPORT_SYMBOL_GPL(rust_helper_init_waitqueue_head);
 
 #ifdef CONFIG_NET_OOB
 void rust_helper__vlan_hwaccel_put_tag(struct sk_buff *skb, __be16 vlan_proto, __u16 vlan_tci) {

--- a/rust/kernel/dovetail.rs
+++ b/rust/kernel/dovetail.rs
@@ -14,6 +14,8 @@ extern "C" {
     #[allow(improper_ctypes)]
     fn rust_helper_dovetail_request_ucall(task: *mut bindings::task_struct);
     fn rust_helper_dovetail_mm_state() -> *mut bindings::oob_mm_state;
+    #[allow(improper_ctypes)]
+    fn rust_helper_dovetail_send_mayday(task: *mut bindings::task_struct);
 }
 
 /// The `dovetail_start` function is a wrapper around the `bindings::dovetail_start` function from the kernel bindings. It starts the Dovetail interface in the kernel.
@@ -160,6 +162,13 @@ pub fn dovetail_leave_oob() {
 pub fn dovetail_request_ucall(ptr: *mut bindings::task_struct) {
     unsafe {
         rust_helper_dovetail_request_ucall(ptr);
+    }
+}
+
+/// send mayday signals to userland thread.
+pub fn dovetail_send_mayday(ptr: *mut bindings::task_struct) {
+    unsafe {
+        rust_helper_dovetail_send_mayday(ptr);
     }
 }
 

--- a/rust/kernel/sched.rs
+++ b/rust/kernel/sched.rs
@@ -6,6 +6,17 @@
 
 use crate::{bindings, c_types, types};
 
+extern "C" {
+    fn rust_helper_set_current_state(state: i64);
+}
+
+/// The `set_current_state` function is a wrapper around the `bindings::set_current_state` macro from the kernel.
+pub fn set_current_state(state: i64) {
+    unsafe {
+        rust_helper_set_current_state(state);
+    }
+}
+
 /// The `schedule` function is a wrapper around the `bindings::schedule` function from the kernel bindings.
 pub fn schedule() {
     unsafe {

--- a/rust/kernel/waitqueue.rs
+++ b/rust/kernel/waitqueue.rs
@@ -4,8 +4,8 @@
 //!
 //! C header: [`include/linux/wait.h`](../../../../include/linux/wait.h)
 
-use crate::{bindings, c_types::*};
-use core::ptr;
+use crate::{bindings, c_types::*, types::Opaque};
+use core::marker::PhantomPinned;
 
 extern "C" {
     fn rust_helper_add_wait_queue(
@@ -16,15 +16,21 @@ extern "C" {
         wq_head: *mut bindings::wait_queue_head,
         condition: bool,
     ) -> i32;
+    fn rust_helper_init_waitqueue_head(wq: *mut bindings::wait_queue_head);
     #[allow(improper_ctypes)]
     fn __init_waitqueue_head(
         wq_head: *mut bindings::wait_queue_head,
         name: *const c_char,
         arg1: *mut bindings::lock_class_key,
     );
+    fn rust_helper_spin_lock_irqsave(lock: *mut bindings::spinlock_t) -> u64;
+    fn rust_helper_spin_unlock_irqrestore(lock: *mut bindings::spinlock_t, flags: u64);
     fn rust_helper_wq_has_sleeper(wq_head: *mut bindings::wait_queue_head) -> bool;
     fn rust_helper_raw_spin_lock_irqsave(lock: *mut bindings::hard_spinlock_t) -> u64;
     fn rust_helper_raw_spin_unlock_irqrestore(lock: *mut bindings::hard_spinlock_t, flags: u64);
+    fn rust_helper_waitqueue_active(wq: *mut bindings::wait_queue_head) -> bool;
+    fn rust_helper_list_empty(list: *const bindings::list_head) -> bool;
+    fn rust_helper_list_del(list: *mut bindings::list_head);
 }
 
 /// The `LockClassKey` struct wraps a `bindings::lock_class_key` struct from the kernel bindings.
@@ -34,59 +40,119 @@ pub struct LockClassKey {
 }
 
 /// The `WaitQueueEntry` struct wraps a `bindings::wait_queue_entry_t` struct from the kernel bindings.
-#[derive(Default)]
+#[repr(transparent)]
 pub struct WaitQueueEntry {
-    wait_queue_entry: bindings::wait_queue_entry_t,
+    wait_queue_entry: Opaque<bindings::wait_queue_entry_t>,
+
+    /// A WaitQueueEntry needs to be pinned because it contains a [`struct list_head`] that is
+    /// self-referential, so it cannot be safely moved once it is initialised.
+    _pin: PhantomPinned,
 }
 
 impl WaitQueueEntry {
+    /// Construct a new default struct.
+    /// Safety: The caller must ensure that the returned struct is initialised before use.
+    pub unsafe fn new() -> Self {
+        WaitQueueEntry {
+            wait_queue_entry: Opaque::uninit(),
+            _pin: PhantomPinned,
+        }
+    }
+
     /// A wrapper around the `bindings::init_wait_entry` function from the kernel bindings.
     pub fn init_wait_entry(&mut self, flags: c_int) {
+        // Safety: `wait_queue_entry` points to valid memory.
         unsafe {
-            bindings::init_wait_entry(
-                &mut self.wait_queue_entry as *mut bindings::wait_queue_entry,
-                flags,
+            bindings::init_wait_entry(self.wait_queue_entry.get(), flags);
+        }
+    }
+
+    /// Call `list_empty` from the rust_helper.
+    pub fn list_empty(&self) -> bool {
+        // Safety: `wait_queue_entry` points to valid memory.
+        unsafe {
+            rust_helper_list_empty(
+                &(*self.wait_queue_entry.get()).entry as *const bindings::list_head,
+            )
+        }
+    }
+
+    /// Call `list_del` from the rust_helper to delete the entry from the list.
+    pub fn list_del(&mut self) {
+        // Safety: `wait_queue_entry.entry` points to valid memory.
+        unsafe {
+            rust_helper_list_del(
+                &mut (*self.wait_queue_entry.get()).entry as *mut bindings::list_head,
             );
         }
     }
 }
 
 /// The `WaitQueueHead` struct wraps a `bindings::wait_queue_head_t` function from the kernel bindings.
-#[derive(Default)]
+#[repr(transparent)]
 pub struct WaitQueueHead {
-    wait_queue_head: bindings::wait_queue_head_t,
+    wait_queue_head: Opaque<bindings::wait_queue_head>,
+
+    /// A WaitQueueHead needs to be pinned because it contains a [`struct list_head`] that is
+    /// self-referential, so it cannot be safely moved once it is initialised.
+    _pin: PhantomPinned,
 }
 
 impl WaitQueueHead {
     /// Construct a new default struct.
+    //TODO: combine new and init or refactor it like [`sync::CondVar`]
     pub fn new() -> Self {
         WaitQueueHead {
-            wait_queue_head: bindings::wait_queue_head_t {
-                lock: bindings::spinlock_t {
-                    _bindgen_opaque_blob: 0,
-                },
-                head: bindings::list_head {
-                    next: ptr::null_mut(),
-                    prev: ptr::null_mut(),
-                },
-            },
+            wait_queue_head: Opaque::uninit(),
+            _pin: PhantomPinned,
+        }
+    }
+
+    /// Call `init_waitqueue_head` macro from the rust_helper.
+    pub fn init(&mut self) {
+        // Safety: `wait_queue_head` points to valid memory.
+        unsafe {
+            rust_helper_init_waitqueue_head(self.wait_queue_head.get());
+        }
+    }
+
+    /// Call `spin_lock_irqsave` from the rust_helper.
+    pub fn spin_lock_irqsave(&mut self) -> u64 {
+        // Safety: The caller guarantees that self is initialised. So the pointer is valid.
+        unsafe {
+            rust_helper_spin_lock_irqsave(
+                &mut (*self.wait_queue_head.get()).lock as *mut bindings::spinlock_t,
+            )
+        }
+    }
+
+    /// Call `spin_unlock_irqrestore` from the rust_helper.
+    pub fn spin_unlock_irqrestore(&mut self, flags: u64) {
+        // Safety: The caller guarantees that self is initialised. So the pointer is valid.
+        unsafe {
+            rust_helper_spin_unlock_irqrestore(
+                &mut (*self.wait_queue_head.get()).lock as *mut bindings::spinlock_t,
+                flags,
+            );
         }
     }
 
     /// Call `raw_spin_lock_irqsave` from the rust_helper.
     pub fn raw_spin_lock_irqsave(&mut self) -> u64 {
+        // Safety: The caller guarantees that self is initialised. So the pointer is valid.
         unsafe {
             rust_helper_raw_spin_lock_irqsave(
-                &mut self.wait_queue_head.lock as *mut _ as *mut bindings::hard_spinlock_t,
+                &mut (*self.wait_queue_head.get()).lock as *mut _ as *mut bindings::hard_spinlock_t,
             )
         }
     }
 
     /// Call `raw_spin_unlock_irqstore` from the rust_helper.
     pub fn raw_spin_unlock_irqrestore(&mut self, flags: u64) {
+        // Safety: The caller guarantees that self is initialised. So the pointer is valid.
         unsafe {
             rust_helper_raw_spin_unlock_irqrestore(
-                &mut self.wait_queue_head.lock as *mut _ as *mut bindings::hard_spinlock_t,
+                &mut (*self.wait_queue_head.get()).lock as *mut _ as *mut bindings::hard_spinlock_t,
                 flags,
             );
         }
@@ -94,53 +160,44 @@ impl WaitQueueHead {
 
     /// Call `add_wait_queue` from the rust_helper.
     pub fn add_wait_queue(&mut self, wq_entry: &mut WaitQueueEntry) {
-        let ptr_wq_entry = &mut wq_entry.wait_queue_entry as *mut bindings::wait_queue_entry_t;
+        // Safety: The caller guarantees that self and `wq_entry` are initialised. So the pointers are valid.
         unsafe {
-            rust_helper_add_wait_queue(
-                &mut self.wait_queue_head as *mut bindings::wait_queue_head,
-                ptr_wq_entry,
-            );
+            rust_helper_add_wait_queue(self.wait_queue_head.get(), wq_entry.wait_queue_entry.get());
         }
     }
 
     /// Call `wait_event_interruptible` from the rust_helper.
     pub fn wait_event_interruptible(&mut self, condition: bool) -> i32 {
-        unsafe {
-            rust_helper_wait_event_interruptible(
-                &mut self.wait_queue_head as *mut bindings::wait_queue_head,
-                condition,
-            )
-        }
+        // Safety: The caller guarantees that self is initialised. So the pointer is valid.
+        unsafe { rust_helper_wait_event_interruptible(self.wait_queue_head.get(), condition) }
     }
 
     /// Call `__init_waitqueue_head` function from the kernel.
     pub fn init_waitqueue_head(&mut self, name: *const c_char, arg1: &mut LockClassKey) {
         let ptr_arg1 = &mut arg1.lock_class_key as *mut bindings::lock_class_key;
+        // Safety: The caller guarantees that self is initialised. So the pointer is valid.
         unsafe {
-            __init_waitqueue_head(
-                &mut self.wait_queue_head as *mut bindings::wait_queue_head,
-                name,
-                ptr_arg1,
-            );
+            __init_waitqueue_head(self.wait_queue_head.get(), name, ptr_arg1);
         }
     }
 
     /// A wrapper around the `bindings::__wake_up` from the kernel bindings.
     pub fn wake_up(&mut self, mode: c_uint, nr: c_int, key: *mut c_void) {
+        // Safety: The caller guarantees that self is initialised. So the pointer is valid.
         unsafe {
-            bindings::__wake_up(
-                &mut self.wait_queue_head as *mut bindings::wait_queue_head,
-                mode,
-                nr,
-                key,
-            );
+            bindings::__wake_up(self.wait_queue_head.get(), mode, nr, key);
         }
     }
 
     /// Call `wq_has_sleeper` from the rust_helper.
     pub fn wq_has_sleeper(&mut self) -> bool {
-        unsafe {
-            rust_helper_wq_has_sleeper(&mut self.wait_queue_head as *mut bindings::wait_queue_head)
-        }
+        // Safety: The caller guarantees that self is initialised. So the pointer is valid.
+        unsafe { rust_helper_wq_has_sleeper(self.wait_queue_head.get()) }
+    }
+
+    /// Call `waitqueue_active` from the rust_helper.
+    pub fn waitqueue_active(&mut self) -> bool {
+        // Safety: The caller guarantees that self is initialised. So the pointer is valid.
+        unsafe { rust_helper_waitqueue_active(self.wait_queue_head.get()) }
     }
 }


### PR DESCRIPTION
The stage exclusion lock (stax) is a mechanism designed to serialize access to a shared resource between threads operating in different execution stages. It allows multiple threads within the same stage to share ownership of the lock, ensuring exclusive access to the guarded resource by either in-band or out-of-band threads at any given time. This prevents concurrent access from threads in different stages, facilitating "phased sharing" of resources and ensuring the integrity of critical operations. Stax locks provide a means to safely implement common drivers shared between in-band and out-of-band users, addressing issues of concurrency and synchronization within a multi-stage execution environment.
I have implemented this kernel struct and a corresponding drivers used by libevl's test.