### PR TITLE
Add SMP Support to the RROS Kernel.

### DIFF
--- a/kernel/dovetail.c
+++ b/kernel/dovetail.c
@@ -295,13 +295,13 @@ void inband_event_notify(enum inband_event_type event, void *data)
 		handle_inband_event(event, data);
 }
 
-extern void rust_resume_oob_task(void *ptr);
+extern void rust_resume_oob_task(void *ptr, int cpu);
 
 void __weak resume_oob_task(struct task_struct *p)
 {
 	void *thread = p->thread_info.oob_state.thread;
 	pr_info("the passed thread ptr is %px", thread);
-	rust_resume_oob_task(thread);
+	rust_resume_oob_task(thread, task_cpu(p));
 }
 
 static void finalize_oob_transition(void) /* hard IRQs off */

--- a/kernel/rros/clock.rs
+++ b/kernel/rros/clock.rs
@@ -7,11 +7,9 @@ use crate::{
     lock::*,
     monitor::{CLOCK_MONOTONIC, CLOCK_REALTIME},
     poll::RrosPollHead,
-    sched::{rros_cpu_rq, this_rros_rq, RQ_TDEFER, RQ_TIMER, RQ_TPROXY},
-    thread::T_ROOT,
-    thread::{rros_current, rros_delay, T_SYSRST},
-    tick,
-    tick::*,
+    sched::{self, rros_cpu_rq, rros_get_thread_rq, rros_rq, rros_rq_cpu, this_rros_rq, RQ_TDEFER, RQ_TIMER, RQ_TPROXY},
+    thread::{rros_current, rros_delay, T_ROOT, T_SYSRST},
+    tick::{self, *},
     timeout::{RrosTmode, RROS_INFINITE},
     timer::*,
     tp::rros_timer_is_running,
@@ -27,13 +25,15 @@ use core::{
     clone::Clone,
     mem::{align_of, size_of},
     ops::{Deref, DerefMut},
+    cmp::Ordering::{Equal, Less, Greater},
 };
 
 use kernel::{
     bindings,
     c_types::{self, c_void},
     chrdev::Cdev,
-    clockchips, cpumask,
+    clockchips,
+    cpumask::{self, CpumaskT},
     device::DeviceType,
     double_linked_list::*,
     file::File,
@@ -172,7 +172,7 @@ pub struct RrosClock {
     element: Option<Rc<RefCell<RrosElement>>>,
     dispose: Option<fn(&mut RrosClock)>,
     #[cfg(CONFIG_SMP)]
-    pub affinity: Option<cpumask::CpumaskT>,
+    pub affinity: Option<CpumaskT>,
 }
 
 impl RrosClock {
@@ -188,7 +188,7 @@ impl RrosClock {
         next: *mut ListHead,
         element: Option<Rc<RefCell<RrosElement>>>,
         dispose: Option<fn(&mut RrosClock)>,
-        #[cfg(CONFIG_SMP)] affinity: Option<cpumask::CpumaskT>,
+        #[cfg(CONFIG_SMP)] affinity: Option<CpumaskT>,
     ) -> Self {
         RrosClock {
             resolution,
@@ -279,6 +279,10 @@ impl RrosClock {
         self.offset
     }
 
+    // TODO: We'd better change `get_master` to `master`, so as other functions.
+    // But it is not a big problem here.
+    // FYI: https://github.com/BUPT-OS/RROS/pull/41#discussion_r1680743392
+    // FYI: https://rust-lang.github.io/api-guidelines/naming.html#getter-names-follow-rust-convention-c-getter
     pub fn get_master(&self) -> *mut RrosClock {
         self.master
     }
@@ -586,13 +590,95 @@ fn set_timer_value(timer: Arc<SpinLock<RrosTimer>>, value: &Itimerspec64) -> Res
     return Ok(0);
 }
 
+// TODO: Can we use a static reference or something safe else?
+pub fn rros_current_rq() -> *mut rros_rq {
+    let current = rros_current();
+    unsafe { (*(*current).locked_data().get()).rq.unwrap() }
+}
+
+pub fn double_timer_base_lock(tb1: *mut RrosTimerbase, tb2: *mut RrosTimerbase) {
+    match tb1.cmp(&tb2) {
+        Equal   => unsafe { (*tb1).lock.raw_spin_lock() },
+        Less    => unsafe {
+            (*tb1).lock.raw_spin_lock();
+            (*tb2).lock.raw_spin_lock_nested(bindings::SINGLE_DEPTH_NESTING);
+        },
+        Greater => unsafe {
+            (*tb2).lock.raw_spin_lock();
+            (*tb1).lock.raw_spin_lock_nested(bindings::SINGLE_DEPTH_NESTING);
+        },
+    }
+}
+
+pub fn double_timer_base_unlock(tb1: *mut RrosTimerbase, tb2: *mut RrosTimerbase) {
+    unsafe {
+        (*tb1).lock.raw_spin_unlock();
+        if tb1 != tb2 {
+            (*tb2).lock.raw_spin_unlock();
+        }
+    }
+}
+
+// TODO: There are many global static references in the code that are used as raw pointers, such as
+// `RrosClock`, `RrosTimerbase`, `RrosRq`. Maybe we can use references to avoid so many raw pointers.
+// FYI: https://github.com/BUPT-OS/RROS/pull/41#discussion_r1680738528
+pub fn rros_move_timer(timer: Arc<SpinLock<RrosTimer>>, clock: *mut RrosClock, mut rq: *mut rros_rq) {
+    let cpu = get_clock_cpu(unsafe { &(*(*clock).get_master()) }, rros_rq_cpu(rq));
+    rq = rros_cpu_rq(cpu);
+
+    let mut flags: u64 = 0;
+    let old_base = lock_timer_base(timer.clone(), &mut flags);
+    
+    if rros_timer_on_rq(timer.clone(), rq) && clock == unsafe { (*timer.locked_data().get()).get_clock() } {
+        unlock_timer_base(timer.clone(), flags);
+        return;
+    }
+    let new_base = rros_percpu_timers(unsafe { &(*(*clock).get_master()) }, cpu);
+    if unsafe { (*timer.locked_data().get()).get_status() & RROS_TIMER_RUNNING } != 0 {
+        stop_timer_locked(timer.clone());
+        unlock_timer_base(timer.clone(), flags);
+        let flags: u64 = raw_spin_lock_irqsave();
+        double_timer_base_lock(old_base, new_base);
+        
+        unsafe {
+            #[cfg(CONFIG_SMP)]
+            (*timer.locked_data().get()).set_rq(rq);
+
+            (*timer.locked_data().get()).set_base(new_base);
+            (*timer.locked_data().get()).set_clock(clock);
+        }
+        rros_enqueue_timer(timer.clone(), unsafe { &mut (*new_base).q });
+        if timer_at_front(timer.clone()) {
+            rros_program_remote_tick(clock, rq);
+        }
+        double_timer_base_unlock(old_base, new_base);
+        raw_spin_unlock_irqrestore(flags);
+    } else {
+        unsafe {
+            #[cfg(CONFIG_SMP)]
+            (*timer.locked_data().get()).set_rq(rq);
+
+            (*timer.locked_data().get()).set_base(new_base);
+            (*timer.locked_data().get()).set_clock(clock);
+        }
+        unlock_timer_base(timer.clone(), flags);
+    }
+}
+
 #[cfg(CONFIG_SMP)]
 fn pin_timer(timer: Arc<SpinLock<RrosTimer>>) {
-    //TODO: complete this func when smp is useful
+    let flags = raw_spin_lock_irqsave();
+
+    let this_rq = rros_current_rq();
+    if unsafe { (*timer.locked_data().get()).get_rq() != this_rq } {
+        rros_move_timer(timer.clone(), unsafe { (*timer.locked_data().get()).get_clock() }, this_rq);
+    }
+
+    raw_spin_unlock_irqrestore(flags);
 }
 
 #[cfg(not(CONFIG_SMP))]
-fn pin_timer(timer: Arc<SpinLock<RrosTimer>>) {}
+fn pin_timer(_timer: Arc<SpinLock<RrosTimer>>) {}
 
 fn set_timerfd(
     timerfd: &RrosTimerFd,
@@ -1090,8 +1176,10 @@ fn rros_init_slave_clock(clock: &mut RrosClock, master: &mut RrosClock) -> Resul
     premmpt::running_inband()?;
 
     // TODO: Check if there is a problem here, even if the timer can run.
-    // #[cfg(CONFIG_SMP)]
-    // clock.affinity = master.affinity;
+    #[cfg(CONFIG_SMP)]
+    {
+        clock.affinity = master.affinity.clone();
+    }
 
     clock.timerdata = master.get_timerdata_addr();
     clock.offset = clock.read() - master.read();
@@ -1099,8 +1187,26 @@ fn rros_init_slave_clock(clock: &mut RrosClock, master: &mut RrosClock) -> Resul
     Ok(0)
 }
 
-fn rros_init_clock(clock: &mut RrosClock, affinity: &cpumask::CpumaskT) -> Result<usize> {
+fn rros_init_clock(clock: &mut RrosClock, affinity: &CpumaskT) -> Result<usize> {
     premmpt::running_inband()?;
+
+    #[cfg(CONFIG_SMP)]
+    {
+        if clock.affinity.is_none() {
+            clock.affinity = Some(CpumaskT::from_int(0));
+        }
+        if affinity.cpumask_empty().is_ok() {
+            let clock_affinity = clock.affinity.as_mut().unwrap();
+            clock_affinity.cpumask_clear();
+            clock_affinity.cpumask_set_cpu(unsafe { RROS_OOB_CPUS.cpumask_first() as u32 });
+        } else {
+            clock.affinity = Some(affinity.clone() & unsafe { RROS_OOB_CPUS.clone() });
+            if clock.affinity.as_ref().unwrap().cpumask_empty().is_ok() {
+                return Err(Error::EINVAL);
+            }
+        }
+    }
+
     // 8 byte alignment
     let tmb = percpu::alloc_per_cpu(
         size_of::<RrosTimerbase>() as usize,

--- a/kernel/rros/clock_test.rs
+++ b/kernel/rros/clock_test.rs
@@ -92,7 +92,7 @@ pub fn test_rros_adjust_timers() -> Result<usize> {
         (*tmb).q.add_head(yy.clone());
 
         pr_debug!("before adjust_timer");
-        rros_adjust_timers(&mut RROS_MONO_CLOCK, 100);
+        rros_adjust_timers(&mut RROS_MONO_CLOCK, 100)?;
         pr_debug!("len of tmb is {}", (*tmb).q.len());
     }
     pr_debug!("~~~test_rros_adjust_timers end~~~");

--- a/kernel/rros/flags.rs
+++ b/kernel/rros/flags.rs
@@ -1,6 +1,5 @@
 use crate::{
     clock::{RrosClock, RROS_MONO_CLOCK},
-    lock::{raw_spin_lock_irqsave, raw_spin_unlock_irqrestore},
     sched::rros_schedule,
     timeout::{RrosTmode, RROS_INFINITE},
     wait::{RrosWaitQueue, RROS_WAIT_PRIO},
@@ -100,10 +99,9 @@ impl RrosFlag {
 
     #[inline]
     pub fn flush_nosched(&mut self, reason: i32) {
-        let flags: u64;
-        flags = raw_spin_lock_irqsave();
+        let flags: u64 = self.wait.lock.raw_spin_lock_irqsave();
         self.wait.flush_locked(reason);
-        raw_spin_unlock_irqrestore(flags);
+        self.wait.lock.raw_spin_unlock_irqrestore(flags);
     }
 }
 

--- a/kernel/rros/flags.rs
+++ b/kernel/rros/flags.rs
@@ -54,7 +54,9 @@ impl RrosFlag {
 
     #[inline]
     pub fn peek(cell: &Cell<bool>) -> bool {
-        unsafe { rust_helper_smp_wmb(); }
+        unsafe {
+            rust_helper_smp_wmb();
+        }
         cell.get()
     }
 
@@ -72,33 +74,23 @@ impl RrosFlag {
     pub fn wait(&mut self) -> i32 {
         let cell = &self.raised;
 
-        self.wait.wait_timeout(
-            RROS_INFINITE,
-            RrosTmode::RrosRel,
-            || Self::read(cell),
-        )
+        self.wait
+            .wait_timeout(RROS_INFINITE, RrosTmode::RrosRel, || Self::read(cell))
     }
 
     #[inline]
     pub fn wait_same(&mut self) -> i32 {
         let cell = &self.raised;
 
-        self.wait.wait_timeout(
-            RROS_INFINITE,
-            RrosTmode::RrosRel,
-            || Self::peek(cell),
-        )
+        self.wait
+            .wait_timeout(RROS_INFINITE, RrosTmode::RrosRel, || Self::peek(cell))
     }
 
     #[inline]
     pub fn wait_timeout(&mut self, timeout: KtimeT, tmode: RrosTmode) -> i32 {
         let cell = &self.raised;
 
-        self.wait.wait_timeout(
-            timeout,
-            tmode,
-            || Self::read(cell),
-        )
+        self.wait.wait_timeout(timeout, tmode, || Self::read(cell))
     }
 
     #[inline]

--- a/kernel/rros/init.rs
+++ b/kernel/rros/init.rs
@@ -74,10 +74,10 @@ mod work;
 #[macro_use]
 pub mod types;
 mod proxy;
+mod smp_test;
 mod types_test;
 mod wait;
 mod xbuf;
-mod smp_test;
 
 #[cfg(CONFIG_NET)]
 mod net;
@@ -356,7 +356,8 @@ impl KernelModule for Rros {
         };
         if str::from_utf8(oobcpus_arg.read())? != "" {
             let res = unsafe {
-                RROS_OOB_CPUS.cpulist_parse(CStr::from_bytes_with_nul(oobcpus_arg.read())?.as_char_ptr())
+                RROS_OOB_CPUS
+                    .cpulist_parse(CStr::from_bytes_with_nul(oobcpus_arg.read())?.as_char_ptr())
             };
             match res {
                 Ok(_o) => (pr_info!("load parameters {}\n", str::from_utf8(oobcpus_arg.read())?)),
@@ -373,7 +374,9 @@ impl KernelModule for Rros {
             }
         }
 
-        unsafe { RROS_CPU_AFFINITY.cpumask_copy(&RROS_OOB_CPUS); }
+        unsafe {
+            RROS_CPU_AFFINITY.cpumask_copy(&RROS_OOB_CPUS);
+        }
 
         let res = init_core(); //*sysheap_size_arg.read()
         let fac_reg;

--- a/kernel/rros/init.rs
+++ b/kernel/rros/init.rs
@@ -77,6 +77,7 @@ mod proxy;
 mod types_test;
 mod wait;
 mod xbuf;
+mod smp_test;
 
 #[cfg(CONFIG_NET)]
 mod net;
@@ -92,7 +93,7 @@ module! {
     license: b"GPL v2",
     params: {
         oobcpus_arg: str {
-            default: b"0-1\0",
+            default: b"0-7\0",
             permissions: 0o444,
             description: b"which cpus in the oob",
         },
@@ -330,6 +331,12 @@ fn test_mem() {
 fn test_lantency() {
     rros::latmus::test_latmus();
 }
+
+#[allow(dead_code)]
+fn test_smp() {
+    smp_test::smp_test_parallel_execution();
+}
+
 impl KernelModule for Rros {
     fn init() -> Result<Self> {
         pr_info!("Hello world from rros!\n");
@@ -399,6 +406,8 @@ impl KernelModule for Rros {
             }
         }
         test_lantency();
+
+        test_smp();
 
         // let mut rros_kthread1 = rros_kthread::new(fn1);
         // let mut rros_kthread2 = rros_kthread::new(fn2);

--- a/kernel/rros/lock.rs
+++ b/kernel/rros/lock.rs
@@ -17,19 +17,12 @@ extern "C" {
     // fn rust_helper_raw_spin_unlock_irqrestore();
 }
 
-// TODO: modify this when we have the real smp support
-pub fn raw_spin_lock_irqsave() -> c_types::c_ulong {
-    let flags = unsafe { rust_helper_hard_local_irq_save() };
-    // unsafe{rust_helper_preempt_disable();}
-    return flags;
+pub fn hard_local_irq_save() -> u64 {
+    unsafe { rust_helper_hard_local_irq_save() }
 }
 
-// TODO: modify this when we have the real smp support
-pub fn raw_spin_unlock_irqrestore(flags: c_types::c_ulong) {
-    unsafe {
-        rust_helper_hard_local_irq_restore(flags);
-        // rust_helper_preempt_enable();
-    }
+pub fn hard_local_irq_restore(flags: u64) {
+    unsafe { rust_helper_hard_local_irq_restore(flags); }
 }
 
 // pub fn right_raw_spin_lock_irqsave(lock: *mut spinlock_t, flags: *mut u32) {

--- a/kernel/rros/lock.rs
+++ b/kernel/rros/lock.rs
@@ -22,7 +22,9 @@ pub fn hard_local_irq_save() -> u64 {
 }
 
 pub fn hard_local_irq_restore(flags: u64) {
-    unsafe { rust_helper_hard_local_irq_restore(flags); }
+    unsafe {
+        rust_helper_hard_local_irq_restore(flags);
+    }
 }
 
 // pub fn right_raw_spin_lock_irqsave(lock: *mut spinlock_t, flags: *mut u32) {

--- a/kernel/rros/net/input.rs
+++ b/kernel/rros/net/input.rs
@@ -28,7 +28,7 @@ pub struct RrosNetRxqueue {
 }
 
 impl RrosNetRxqueue {
-    // TODO: 使用Rc<Refcell<>>来替代
+    // TODO: replace this with Rc<Refcell<>>
     pub fn new(hkey: u32) -> Option<NonNull<Self>> {
         extern "C" {
             fn rust_helper_INIT_LIST_HEAD(list: *mut bindings::list_head);

--- a/kernel/rros/sched.rs
+++ b/kernel/rros/sched.rs
@@ -250,10 +250,7 @@ pub fn rros_set_resched(rq_op: Option<*mut rros_rq>) {
         unsafe {
             (*rq).add_flags(RQ_SCHED);
             (*this_rq).add_local_flags(RQ_SCHED);
-            cpumask::cpumask_set_cpu(
-                rros_rq_cpu(rq) as u32,
-                (*this_rq).resched_cpus.as_cpumas_ptr(),
-            );
+            (*this_rq).resched_cpus.cpumask_set_cpu(rros_rq_cpu(rq) as u32);
         }
     }
 }

--- a/kernel/rros/sched.rs
+++ b/kernel/rros/sched.rs
@@ -42,7 +42,7 @@ use crate::{
     timeout::RROS_INFINITE,
     timer::*,
     tp,
-    wait::{RrosWaitChannel, RrosWaitQueue, RROS_WAIT_PRIO},
+    wait::RrosWaitChannel,
     RROS_MACHINE_CPUDATA, RROS_OOB_CPUS,
 };
 

--- a/kernel/rros/sched.rs
+++ b/kernel/rros/sched.rs
@@ -42,7 +42,8 @@ use crate::{
     timeout::RROS_INFINITE,
     timer::*,
     tp,
-    wait::{RrosWaitChannel, RrosWaitQueue, RROS_WAIT_PRIO}, RROS_MACHINE_CPUDATA,
+    wait::{RrosWaitChannel, RrosWaitQueue, RROS_WAIT_PRIO},
+    RROS_MACHINE_CPUDATA, RROS_OOB_CPUS,
 };
 
 extern "C" {
@@ -269,6 +270,11 @@ pub fn is_threading_cpu(cpu: i32) -> bool {
 #[cfg(not(CONFIG_SMP))]
 pub fn is_threading_cpu(cpu: i32) -> bool {
     return true;
+}
+
+#[cfg(CONFIG_SMP)]
+pub fn is_rros_cpu(cpu: i32) -> bool {
+    unsafe { RROS_OOB_CPUS.cpumask_test_cpu(cpu as u32) }
 }
 
 #[cfg(not(CONFIG_SMP))]

--- a/kernel/rros/sched.rs
+++ b/kernel/rros/sched.rs
@@ -1948,8 +1948,6 @@ pub unsafe extern "C" fn rros_schedule() {
 }
 
 extern "C" {
-    fn rust_helper_hard_local_irq_save() -> c_types::c_ulong;
-    fn rust_helper_hard_local_irq_restore(flags: c_types::c_ulong);
     #[allow(dead_code)]
     fn rust_helper_preempt_enable();
     #[allow(dead_code)]
@@ -1968,7 +1966,7 @@ unsafe extern "C" fn __rros_schedule(_arg: *mut c_types::c_void) -> i32 {
         let this_rq = this_rros_rq();
         let mut leaving_inband;
 
-        let flags = rust_helper_hard_local_irq_save();
+        let flags = lock::hard_local_irq_save();
 
         curr = (*this_rq).get_curr();
 
@@ -1985,7 +1983,7 @@ unsafe extern "C" fn __rros_schedule(_arg: *mut c_types::c_void) -> i32 {
             // raw_spin_unlock(&this_rq->lock);
             // raw_spin_unlock_irqrestore(&curr->lock, flags);
             // rust_helper_hard_local_irq_restore(flags);
-            lock::raw_spin_unlock_irqrestore(flags);
+            lock::hard_local_irq_restore(flags);
             return 0;
         }
 
@@ -2012,7 +2010,7 @@ unsafe extern "C" fn __rros_schedule(_arg: *mut c_types::c_void) -> i32 {
                 }
             }
             // rust_helper_hard_local_irq_restore(flags);
-            lock::raw_spin_unlock_irqrestore(flags);
+            lock::hard_local_irq_restore(flags);
             return 0;
         }
 
@@ -2067,7 +2065,7 @@ unsafe extern "C" fn __rros_schedule(_arg: *mut c_types::c_void) -> i32 {
 
         pr_debug!("the inband_tail is {}", inband_tail);
         if inband_tail == false {
-            lock::raw_spin_unlock_irqrestore(flags);
+            lock::hard_local_irq_restore(flags);
         }
         pr_debug!(
             "end of the rros_schedule uninit_thread: x ref is {}",
@@ -2243,7 +2241,7 @@ pub fn rros_get_thread_rq(
 ) -> Option<*mut rros_rq> {
     // pr_debug!("yinyongcishu is {}", Arc::strong_count(&thread.clone().unwrap()));
     //todo raw_spin_lock_irqsave and raw_spin_lock
-    *flags = unsafe { rust_helper_hard_local_irq_save() };
+    *flags = lock::hard_local_irq_save();
     // unsafe{rust_helper_preempt_disable();}
     unsafe { (*thread.unwrap().locked_data().get()).rq.clone() }
 }
@@ -2253,10 +2251,11 @@ pub fn rros_put_thread_rq(
     _rq: Option<*mut rros_rq>,
     flags: c_types::c_ulong,
 ) -> Result<usize> {
-    unsafe {
-        rust_helper_hard_local_irq_restore(flags);
-        // rust_helper_preempt_enable();
-    }
+    // unsafe {
+    //     rust_helper_hard_local_irq_restore(flags);
+    //     // rust_helper_preempt_enable();
+    // }
+    lock::hard_local_irq_restore(flags);
     // TODO: raw_spin_unlock and raw_spin_unlock_irqrestore
     Ok(0)
 }

--- a/kernel/rros/smp_test.rs
+++ b/kernel/rros/smp_test.rs
@@ -1,12 +1,6 @@
-use crate::{
-    flags::RrosFlag,
-    thread::KthreadRunner,
-};
+use crate::{flags::RrosFlag, thread::KthreadRunner};
 
-use kernel::{
-    c_str,
-    prelude::*,
-};
+use kernel::{c_str, prelude::*};
 
 static mut FLAG_PTR: *mut RrosFlag = 0 as *mut RrosFlag;
 
@@ -29,7 +23,11 @@ fn kthread_fn(id: i32) {
         first = second;
         second = temp;
     }
-    pr_warn!("[smp_test]: kthread id is {:?}, the calculation result is {:?}", id, second);
+    pr_warn!(
+        "[smp_test]: kthread id is {:?}, the calculation result is {:?}",
+        id,
+        second
+    );
 }
 
 #[allow(dead_code)]

--- a/kernel/rros/smp_test.rs
+++ b/kernel/rros/smp_test.rs
@@ -1,0 +1,62 @@
+use crate::{
+    flags::RrosFlag,
+    thread::KthreadRunner,
+};
+
+use kernel::{
+    c_str,
+    prelude::*,
+};
+
+static mut FLAG_PTR: *mut RrosFlag = 0 as *mut RrosFlag;
+
+static mut SMP_KTHREAD_RUNNER_1: KthreadRunner = KthreadRunner::new_empty();
+static mut SMP_KTHREAD_RUNNER_2: KthreadRunner = KthreadRunner::new_empty();
+static mut SMP_KTHREAD_RUNNER_3: KthreadRunner = KthreadRunner::new_empty();
+static mut SMP_KTHREAD_RUNNER_4: KthreadRunner = KthreadRunner::new_empty();
+static mut SMP_KTHREAD_RUNNER_5: KthreadRunner = KthreadRunner::new_empty();
+static mut SMP_KTHREAD_RUNNER_6: KthreadRunner = KthreadRunner::new_empty();
+
+fn kthread_fn(id: i32) {
+    unsafe {
+        (*FLAG_PTR).wait_same();
+    }
+
+    let (mut first, mut second) = (1, 1);
+    const M: i64 = 1_000_000_007;
+    for _ in 0..5_000_000_0 {
+        let temp = (first + second) % M;
+        first = second;
+        second = temp;
+    }
+    pr_warn!("[smp_test]: kthread id is {:?}, the calculation result is {:?}", id, second);
+}
+
+#[allow(dead_code)]
+pub fn smp_test_parallel_execution() {
+    let smp_flag = Box::try_new(RrosFlag::new()).unwrap();
+
+    unsafe {
+        FLAG_PTR = Box::into_raw(smp_flag);
+
+        SMP_KTHREAD_RUNNER_1.init(Box::try_new(|| kthread_fn(1)).unwrap());
+        SMP_KTHREAD_RUNNER_1.run(c_str!("smp_test_kthread_1"));
+
+        SMP_KTHREAD_RUNNER_2.init(Box::try_new(|| kthread_fn(2)).unwrap());
+        SMP_KTHREAD_RUNNER_2.run(c_str!("smp_test_kthread_2"));
+
+        SMP_KTHREAD_RUNNER_3.init(Box::try_new(|| kthread_fn(3)).unwrap());
+        SMP_KTHREAD_RUNNER_3.run(c_str!("smp_test_kthread_3"));
+
+        SMP_KTHREAD_RUNNER_4.init(Box::try_new(|| kthread_fn(4)).unwrap());
+        SMP_KTHREAD_RUNNER_4.run(c_str!("smp_test_kthread_4"));
+
+        SMP_KTHREAD_RUNNER_5.init(Box::try_new(|| kthread_fn(5)).unwrap());
+        SMP_KTHREAD_RUNNER_5.run(c_str!("smp_test_kthread_5"));
+
+        SMP_KTHREAD_RUNNER_6.init(Box::try_new(|| kthread_fn(6)).unwrap());
+        SMP_KTHREAD_RUNNER_6.run(c_str!("smp_test_kthread_6"));
+
+        (*FLAG_PTR).raise();
+    }
+}

--- a/kernel/rros/syscall.rs
+++ b/kernel/rros/syscall.rs
@@ -174,7 +174,11 @@ fn prepare_for_signal(
     // * @curr->lock (i.e. @curr cannot go away under out feet).
     // */
     // [TODO: use the curr rq lock to make smp work]
-    flags = unsafe { (*(*(*curr).locked_data().get()).rq.unwrap()).lock.raw_spin_lock_irqsave() };
+    flags = unsafe {
+        (*(*(*curr).locked_data().get()).rq.unwrap())
+            .lock
+            .raw_spin_lock_irqsave()
+    };
 
     // /*
     // * We are called from out-of-band mode only to act upon a
@@ -197,7 +201,11 @@ fn prepare_for_signal(
         }
     }
 
-    unsafe { (*(*(*curr).locked_data().get()).rq.unwrap()).lock.raw_spin_unlock_irqrestore(flags); }
+    unsafe {
+        (*(*(*curr).locked_data().get()).rq.unwrap())
+            .lock
+            .raw_spin_unlock_irqrestore(flags);
+    }
 
     rros_test_cancel();
 

--- a/kernel/rros/thread.rs
+++ b/kernel/rros/thread.rs
@@ -2454,7 +2454,7 @@ impl KthreadRunner {
 }
 
 pub fn rros_set_period(
-    _clock: &mut clock::RrosClock,
+    clock: &mut clock::RrosClock,
     idate: ktime::KtimeT,
     period: ktime::KtimeT,
     flag: i32,
@@ -2506,8 +2506,11 @@ pub fn rros_set_period(
     let flags = raw_spin_lock_irqsave();
     // raw_spin_lock_irqsave(&curr->lock, flags);
 
-    // TODO: when add the real smp function, we nned to add the move
-    // rros_prepare_timed_wait(&curr->ptimer, clock, rros_thread_rq(curr));
+    timer::rros_prepare_timed_wait(
+        timer.clone(),
+        clock,
+        unsafe { (*thread.locked_data().get()).rq.unwrap() }
+    );
 
     // TODO: add this function
     // if (timeout_infinite(idate))

--- a/kernel/rros/thread.rs
+++ b/kernel/rros/thread.rs
@@ -3,8 +3,7 @@ use crate::{
     factory::{self, rros_init_element, RrosElement, RrosFactory},
     fifo::{self, RROS_SCHED_FIFO},
     file::RrosFileBinding,
-    idle,
-    lock,
+    idle, lock,
     sched::*,
     timeout,
     timer::{self, program_timer, rros_dequeue_timer, rros_stop_timer, rros_update_timer_date},
@@ -18,8 +17,8 @@ use core::{
     cell::RefCell,
     clone::Clone,
     ops::DerefMut,
-    result::Result::{Err, Ok},
     ptr,
+    result::Result::{Err, Ok},
 };
 
 #[warn(unused_mut)]
@@ -325,7 +324,8 @@ pub fn rros_init_thread(
     // }
 
     unsafe {
-        (*thread_unwrap.locked_data().get()).affinity = (*iattr_ptr.affinity).clone() & RROS_CPU_AFFINITY.clone();
+        (*thread_unwrap.locked_data().get()).affinity =
+            (*iattr_ptr.affinity).clone() & RROS_CPU_AFFINITY.clone();
     }
 
     thread_unwrap.lock().rq = Some(rq);
@@ -761,12 +761,18 @@ pub fn pin_to_initial_cpu(thread: Arc<SpinLock<RrosThread>>) {
     let name = unsafe { (*thread.locked_data().get()).name };
     pr_debug!("[smp_test]: thread name is {:?}, cpu is {:?}", name, cpu);
 
-    unsafe { bindings::set_cpus_allowed_ptr(current_ptr, CpumaskT::cpumask_of(cpu) as *const _); }
+    unsafe {
+        bindings::set_cpus_allowed_ptr(current_ptr, CpumaskT::cpumask_of(cpu) as *const _);
+    }
 
     let rq = rros_cpu_rq(cpu as i32);
     let flags: u64 = unsafe { (*thread.locked_data().get()).lock.raw_spin_lock_irqsave() };
     rros_migrate_thread(thread.clone(), rq);
-    unsafe { (*thread.locked_data().get()).lock.raw_spin_unlock_irqrestore(flags); }
+    unsafe {
+        (*thread.locked_data().get())
+            .lock
+            .raw_spin_unlock_irqrestore(flags);
+    }
 }
 
 fn map_kthread_self(kthread: &mut RrosKthread) -> Result<usize> {
@@ -2504,11 +2510,9 @@ pub fn rros_set_period(
     // TODO: we should use a guard to avoid manully locking and releasing of locks.
     let flags = thread.irq_lock_noguard();
 
-    timer::rros_prepare_timed_wait(
-        timer.clone(),
-        clock,
-        unsafe { (*thread.locked_data().get()).rq.unwrap() }
-    );
+    timer::rros_prepare_timed_wait(timer.clone(), clock, unsafe {
+        (*thread.locked_data().get()).rq.unwrap()
+    });
 
     // TODO: add this function
     // if (timeout_infinite(idate))

--- a/kernel/rros/thread.rs
+++ b/kernel/rros/thread.rs
@@ -758,6 +758,9 @@ pub fn pin_to_initial_cpu(thread: Arc<SpinLock<RrosThread>>) {
         cpu = unsafe { (*thread.locked_data().get()).affinity.cpumask_first() as u32 };
     }
 
+    let name = unsafe { (*thread.locked_data().get()).name };
+    pr_debug!("[smp_test]: thread name is {:?}, cpu is {:?}", name, cpu);
+
     unsafe { bindings::set_cpus_allowed_ptr(current_ptr, CpumaskT::cpumask_of(cpu) as *const _); }
 
     let rq = rros_cpu_rq(cpu as i32);

--- a/kernel/rros/tick.rs
+++ b/kernel/rros/tick.rs
@@ -1,8 +1,16 @@
 use kernel::{
-    bindings, c_types, clockchips, clockchips::ClockEventDevice, interrupt,
-    irq_pipeline::*, ktime::*, percpu::alloc_per_cpu, percpu_defs, prelude::*, str::CStr,
-    sync::Lock, tick,
-    cpumask::{CpumaskT, num_possible_cpus},
+    bindings, c_types, clockchips,
+    clockchips::ClockEventDevice,
+    cpumask::{num_possible_cpus, CpumaskT},
+    interrupt,
+    irq_pipeline::*,
+    ktime::*,
+    percpu::alloc_per_cpu,
+    percpu_defs,
+    prelude::*,
+    str::CStr,
+    sync::Lock,
+    tick,
 };
 
 use crate::{
@@ -273,5 +281,8 @@ pub fn rros_program_proxy_tick(clock: &RrosClock) {
 
 #[cfg(CONFIG_SMP)]
 pub fn rros_send_timer_ipi(_clock: &RrosClock, rq: *mut RrosRq) {
-    irq_send_oob_ipi(irq_get_timer_oob_ipi(), CpumaskT::cpumask_of(rros_rq_cpu(rq) as u32));
+    irq_send_oob_ipi(
+        irq_get_timer_oob_ipi(),
+        CpumaskT::cpumask_of(rros_rq_cpu(rq) as u32),
+    );
 }

--- a/kernel/rros/timer.rs
+++ b/kernel/rros/timer.rs
@@ -342,7 +342,9 @@ pub fn lock_timer_base(timer: Arc<SpinLock<RrosTimer>>, flags: &mut u64) -> *mut
             if (base == base2) {
                 break;
             }
-            unsafe { (*base).lock.irq_unlock_noguard(*flags); }
+            unsafe {
+                (*base).lock.irq_unlock_noguard(*flags);
+            }
         }
         base
     }
@@ -356,7 +358,9 @@ pub fn lock_timer_base(timer: Arc<SpinLock<RrosTimer>>, flags: &mut u64) -> *mut
 
 #[cfg(CONFIG_SMP)]
 pub fn unlock_timer_base(base: *mut RrosTimerbase, flags: u64) {
-    unsafe { (*base).lock.irq_unlock_noguard(flags); }
+    unsafe {
+        (*base).lock.irq_unlock_noguard(flags);
+    }
 }
 
 #[cfg(not(CONFIG_SMP))]
@@ -419,7 +423,12 @@ pub fn rros_percpu_timers(clock: &RrosClock, cpu: i32) -> *mut RrosTimerbase {
 
 #[cfg(CONFIG_SMP)]
 pub fn get_clock_cpu(clock: &RrosClock, cpu: i32) -> i32 {
-    if clock.affinity.as_ref().unwrap().cpumask_test_cpu(cpu as u32) {
+    if clock
+        .affinity
+        .as_ref()
+        .unwrap()
+        .cpumask_test_cpu(cpu as u32)
+    {
         return cpu;
     }
     clock.affinity.as_ref().unwrap().cpumask_first()
@@ -597,7 +606,11 @@ pub fn rros_abs_timeout(timer: Arc<SpinLock<RrosTimer>>, delta: KtimeT) -> Ktime
 }
 
 #[cfg(CONFIG_SMP)]
-pub fn rros_prepare_timed_wait(timer: Arc<SpinLock<RrosTimer>>, clock: &mut RrosClock, rq: *mut rros_rq) {
+pub fn rros_prepare_timed_wait(
+    timer: Arc<SpinLock<RrosTimer>>,
+    clock: &mut RrosClock,
+    rq: *mut rros_rq,
+) {
     let f: bool = unsafe { (*timer.locked_data().get()).get_clock() != clock as *mut RrosClock };
     let s: bool = unsafe { (*timer.locked_data().get()).get_rq() != rq };
     if f || s {
@@ -606,7 +619,11 @@ pub fn rros_prepare_timed_wait(timer: Arc<SpinLock<RrosTimer>>, clock: &mut Rros
 }
 
 #[cfg(not(CONFIG_SMP))]
-pub fn rros_prepare_timed_wait(timer: Arc<SpinLock<RrosTimer>>, clock: &mut RrosClock, rq: *mut rros_rq) {
+pub fn rros_prepare_timed_wait(
+    timer: Arc<SpinLock<RrosTimer>>,
+    clock: &mut RrosClock,
+    rq: *mut rros_rq,
+) {
     if unsafe { (*timer.locked_data().get()).get_clock() != clock as *mut RrosClock } {
         rros_move_timer(timer, clock, rq);
     }

--- a/kernel/rros/timer_test.rs
+++ b/kernel/rros/timer_test.rs
@@ -413,7 +413,7 @@ pub fn test_rros_destroy_timer() -> Result<usize> {
         rros_destroy_timer(xx.clone());
         let xx_lock_rq = xx.lock().get_rq();
         let xx_lock_base = xx.lock().get_base();
-        if xx_lock_rq == 0 as *mut RrosRq {
+        if xx_lock_rq.is_null() {
             pr_debug!("xx rq is none");
         }
         if xx_lock_base == 0 as *mut RrosTimerbase {

--- a/kernel/rros/xbuf.rs
+++ b/kernel/rros/xbuf.rs
@@ -596,7 +596,9 @@ pub fn inbound_lock(ring: &XbufRing) -> u64 {
 
 pub fn inbound_unlock(ring: &XbufRing, flags: u64) {
     let xbuf = kernel::container_of!(ring, RrosXbuf, ibnd.ring) as *mut RrosXbuf;
-    unsafe { (*xbuf).ibnd.lock.irq_unlock_noguard(flags); }
+    unsafe {
+        (*xbuf).ibnd.lock.irq_unlock_noguard(flags);
+    }
 }
 
 pub fn inbound_wait_input(ring: &XbufRing, len: usize, avail: usize) -> i32 {
@@ -726,7 +728,9 @@ pub fn outbound_lock(ring: &XbufRing) -> u64 {
 
 pub fn outbound_unlock(ring: &XbufRing, flags: u64) {
     let xbuf = kernel::container_of!(ring, RrosXbuf, obnd.ring) as *mut RrosXbuf;
-    unsafe { (*xbuf).obnd.i_event.lock.raw_spin_unlock_irqrestore(flags); }
+    unsafe {
+        (*xbuf).obnd.i_event.lock.raw_spin_unlock_irqrestore(flags);
+    }
 }
 
 pub fn outbound_wait_input(ring: &XbufRing, len: usize, avail: usize) -> i32 {

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -118,7 +118,6 @@ void rust_helper_init_wait(struct wait_queue_entry *wq_entry)
 }
 EXPORT_SYMBOL_GPL(rust_helper_init_wait);
 
-// 此处是wait.h文件中的__add_wait_queue函数的接口
 void rust_helper_add_wait_queue(struct wait_queue_head *wq_head, struct wait_queue_entry *wq_entry)
 {
 	struct list_head *head = &wq_head->head;
@@ -987,7 +986,6 @@ void rust_helper_hash_del(struct hlist_node* node) {
 }
 EXPORT_SYMBOL_GPL(rust_helper_hash_del);
 
-// 这个函数是自己加的
 struct hlist_head* rust_helper_get_hlist_head(struct hlist_head *hashtable,size_t length,u32 key) {
 	return &hashtable[hash_min(key, ilog2(length))];
 }

--- a/rust/helpers.c
+++ b/rust/helpers.c
@@ -314,6 +314,11 @@ void rust_helper_cpumask_copy(struct cpumask *dstp,
 }
 EXPORT_SYMBOL_GPL(rust_helper_cpumask_copy); 
 
+void rust_helper_cpumask_clear(struct cpumask *ptr) {
+	cpumask_clear(ptr);
+}
+EXPORT_SYMBOL_GPL(rust_helper_cpumask_clear);
+
 unsigned long rust_helper_page_align(unsigned long size)
 {
 	return PAGE_ALIGN(size);
@@ -466,6 +471,16 @@ void rust_helper_synchronize_rcu(void)
 	synchronize_rcu();
 }
 EXPORT_SYMBOL_GPL(rust_helper_synchronize_rcu);
+
+void rust_helper_cpus_read_lock(void) {
+	cpus_read_lock();
+}
+EXPORT_SYMBOL_GPL(rust_helper_cpus_read_lock);
+
+void rust_helper_cpus_read_unlock(void) {
+	cpus_read_unlock();
+}
+EXPORT_SYMBOL_GPL(rust_helper_cpus_read_unlock);
 
 void* rust_helper_kthread_run(int (*threadfn)(void *data), void *data, const char namefmt[], ...)
 {
@@ -775,6 +790,21 @@ void rust_helper_raw_spin_lock(hard_spinlock_t *lock) {
 	raw_spin_lock(lock);
 }
 EXPORT_SYMBOL_GPL(rust_helper_raw_spin_lock);
+
+void rust_helper_raw_spin_lock_nested(hard_spinlock_t *lock, unsigned int depth) {
+	raw_spin_lock_nested(lock, depth);
+}
+EXPORT_SYMBOL_GPL(rust_helper_raw_spin_lock_nested);
+
+unsigned int rust_helper_task_cpu(const struct task_struct *p) {
+	return task_cpu(p);
+}
+EXPORT_SYMBOL_GPL(rust_helper_task_cpu);
+
+unsigned int rust_helper_irq_get_RESCHEDULE_OOB_IPI(void) {
+	return RESCHEDULE_OOB_IPI;
+}
+EXPORT_SYMBOL_GPL(rust_helper_irq_get_RESCHEDULE_OOB_IPI);
 
 void rust_helper_raw_spin_unlock(hard_spinlock_t *lock) {
 	raw_spin_unlock(lock);

--- a/rust/kernel/clockchips.rs
+++ b/rust/kernel/clockchips.rs
@@ -244,7 +244,9 @@ pub trait CoreTick {
 
 /// Callback function for trait `CoreTick`.
 pub unsafe extern "C" fn core_tick<T: CoreTick>(dummy: *mut bindings::clock_event_device) {
-    T::core_tick(ClockEventDevice::from_proxy_device(dummy).unwrap());
+    T::core_tick(ClockEventDevice::from_proxy_device(dummy).unwrap_or(ClockEventDevice {
+        ptr: 0 as *mut _,
+    }));
 }
 
 /// A trait to implement functions for `ClockIpiHandle`.

--- a/rust/kernel/clockchips.rs
+++ b/rust/kernel/clockchips.rs
@@ -244,9 +244,9 @@ pub trait CoreTick {
 
 /// Callback function for trait `CoreTick`.
 pub unsafe extern "C" fn core_tick<T: CoreTick>(dummy: *mut bindings::clock_event_device) {
-    T::core_tick(ClockEventDevice::from_proxy_device(dummy).unwrap_or(ClockEventDevice {
-        ptr: 0 as *mut _,
-    }));
+    T::core_tick(
+        ClockEventDevice::from_proxy_device(dummy).unwrap_or(ClockEventDevice { ptr: 0 as *mut _ }),
+    );
 }
 
 /// A trait to implement functions for `ClockIpiHandle`.

--- a/rust/kernel/cpumask.rs
+++ b/rust/kernel/cpumask.rs
@@ -9,10 +9,7 @@ use crate::{
     error::{Error, Result},
 };
 
-use core::{
-    iter::Iterator,
-    ops::BitAnd,
-};
+use core::{iter::Iterator, ops::BitAnd};
 
 extern "C" {
     fn rust_helper_num_possible_cpus() -> u32;

--- a/rust/kernel/irq_pipeline.rs
+++ b/rust/kernel/irq_pipeline.rs
@@ -11,6 +11,7 @@ use crate::{bindings, c_types::*, cpumask};
 extern "C" {
     fn rust_helper_irq_send_oob_ipi(ipi: usize, cpumask: *const cpumask::CpumaskT);
     fn rust_helper_irq_get_TIMER_OOB_IPI() -> usize;
+    fn rust_helper_irq_get_RESCHEDULE_OOB_IPI() -> usize;
 }
 
 /// `irq_send_oob_ipi`: A wrapper around `rust_helper_irq_send_oob_ipi` that sends an out-of-band IPI to the CPUs specified by the `cpumask`. It takes an IPI number and a pointer to a `cpumask::CpumaskT`.
@@ -21,6 +22,11 @@ pub fn irq_send_oob_ipi(ipi: usize, cpumask: *const cpumask::CpumaskT) {
 /// `irq_get_timer_oob_ipi`: A wrapper around `rust_helper_irq_get_TIMER_OOB_IPI` that returns the IPI number for the timer out-of-band interrupt.
 pub fn irq_get_timer_oob_ipi() -> usize {
     unsafe { rust_helper_irq_get_TIMER_OOB_IPI() }
+}
+
+/// `irq_get_reschedule_oob_ipi`: A wrapper around `rust_helper_irq_get_RESCHEDULE_OOB_IPI` that returns the IPI number for the reschedule out-of-band interrupt.
+pub fn irq_get_reschedule_oob_ipi() -> usize {
+    unsafe { rust_helper_irq_get_RESCHEDULE_OOB_IPI() }
 }
 
 /// The `run_oob_call` function is a wrapper around the `bindings::run_oob_cal` function from the kernel bindings.

--- a/rust/kernel/sync/spinlock.rs
+++ b/rust/kernel/sync/spinlock.rs
@@ -126,16 +126,17 @@ impl<T: ?Sized> SpinLock<T> {
     /// The `raw_spin_lock` method acquires the lock.
     pub fn raw_spin_lock(&self) {
         // SAFETY: The caller guarantees that self is initialised. So the pointer is valid.
-        unsafe {
-            rust_helper_raw_spin_lock(self.spin_lock.get() as *mut bindings::hard_spinlock_t)
-        }
+        unsafe { rust_helper_raw_spin_lock(self.spin_lock.get() as *mut bindings::hard_spinlock_t) }
     }
 
     /// The `raw_spin_lock_nested` method acquires the lock nestly.
     pub fn raw_spin_lock_nested(&self, depth: u32) {
         // SAFETY: The caller guarantees that self is initialised. So the pointer is valid.
         unsafe {
-            rust_helper_raw_spin_lock_nested(self.spin_lock.get() as *mut bindings::hard_spinlock_t, depth)
+            rust_helper_raw_spin_lock_nested(
+                self.spin_lock.get() as *mut bindings::hard_spinlock_t,
+                depth,
+            )
         }
     }
 
@@ -258,7 +259,10 @@ impl HardSpinlock {
     pub fn raw_spin_lock_nested(&mut self, depth: u32) {
         // SAFETY: The caller guarantees that self is initialised. So the pointer is valid.
         unsafe {
-            rust_helper_raw_spin_lock_nested(&mut self.lock as *mut bindings::hard_spinlock_t, depth)
+            rust_helper_raw_spin_lock_nested(
+                &mut self.lock as *mut bindings::hard_spinlock_t,
+                depth,
+            )
         }
     }
 }

--- a/rust/kernel/task.rs
+++ b/rust/kernel/task.rs
@@ -16,6 +16,8 @@ extern "C" {
     fn rust_helper_get_task_struct(t: *mut bindings::task_struct);
     #[allow(improper_ctypes)]
     fn rust_helper_put_task_struct(t: *mut bindings::task_struct);
+    #[allow(improper_ctypes)]
+    fn rust_helper_task_cpu(t: *const bindings::task_struct) -> c_types::c_uint;
 }
 
 /// Wraps the kernel's `struct task_struct`.
@@ -100,6 +102,11 @@ impl Task {
     /// The `current_ptr` function returns a raw pointer to the current task. It is unsafe and should be used with caution.
     pub fn current_ptr() -> *mut bindings::task_struct {
         unsafe { rust_helper_get_current() }
+    }
+
+    /// The `task_cpu` function returns a CPU number of the provided `task_struct`.
+    pub fn task_cpu(ptr: *const bindings::task_struct) -> c_types::c_uint {
+        unsafe { rust_helper_task_cpu(ptr) }
     }
 
     /// Returns the group leader of the given task.


### PR DESCRIPTION
As described in #40 , it is essential to provide the `RROS` kernel with support for `SMP`. This `PR` is intended to address that issue.

In this `PR`, the changes are mainly related to the following aspects:

1. Providing support for `SMP` by adding new functionality to the subsystems involved, such as the scheduling subsystem, the clock subsystem, the interrupt subsystem, and so on.
2. Fix lock usage to support multi-`CPU`. When there is only one `CPU` used, turning off interrupts can be used instead of using locks. Therefore, in order to support `SMP`, the areas involved need to be modified to the correct use of locks.
3. Some wrappers in `RFL` are not perfect, so they need to be further improved.
4. Add test code for `SMP`.

Eventually, after testing, `RROS` has been able to support parallel execution of multiple tasks on multiple `CPU`s.

A summary of this `PR` can be found on [my blog](https://jiajundu.github.io/blogs/rros_smp.html). There is also a useful discussion about `SMP` [here](https://lore.kernel.org/xenomai/87ikz4sla4.fsf@xenomai.org/T/#m991042c8f241f58ba1a8791b191b71cd194bacd9).