### PR TITLE
Change the function `rust_handle_inband_event` in `kernel/rros/thread.rs`

### DIFF
--- a/kernel/rros/thread.rs
+++ b/kernel/rros/thread.rs
@@ -1365,26 +1365,24 @@ unsafe extern "C" fn rust_handle_inband_event(
             if rros_current() != 0 as *mut SpinLock<RrosThread> {
                 let _ret = put_current_thread();
             }
-        } // case INBAND_TASK_MIGRATION:
-        // 	handle_migration_event(data);
-        // 	break;
-        // case INBAND_TASK_RETUSER:
-        // 	handle_retuser_event();
-        // 	break;
-        // case INBAND_TASK_PTSTOP:
-        // 	handle_ptstop_event();
-        // 	break;
-        // case INBAND_TASK_PTCONT:
-        // 	handle_ptcont_event();
-        // 	break;
-        // case INBAND_TASK_PTSTEP:
-        // 	handle_ptstep_event(data);
-        // 	break;
-        // case INBAND_PROCESS_CLEANUP:
-        // 	handle_cleanup_event(data);
-        // 	break;
-        _ => {
-            pr_warn!("unknown inband event");
+        }
+        InbandEventType::InbandTaskMigration => {
+            pr_debug!("InbandTaskMigration is not implemented");
+        }
+        InbandEventType::InbandTaskRetuser => {
+            pr_debug!("InbandTaskRetuser is not implemented");
+        }
+        InbandEventType::InbandTaskPtstop => {
+            pr_debug!("InbandTaskPtstop is not implemented");
+        }
+        InbandEventType::InbandTaskPtcont => {
+            pr_debug!("InbandTaskPtcont is not implemented");
+        }
+        InbandEventType::InbandTaskPtstep => {
+            pr_debug!("InbandTaskPtstep is not implemented");
+        }
+        InbandEventType::InbandProcessCleanup => {
+            pr_debug!("InbandProcessCleanup is not implemented");
         }
     }
 }


### PR DESCRIPTION
This function previously print the same warn message when kernel receive different kinds of inband event that is not implemented, I think this makes people fuzzle because the warn information has nothing useful.

Previous code are
https://github.com/BUPT-OS/RROS/blob/129975ae0600ba00a548ac411591c60d291c807c/kernel/rros/thread.rs#L1353-L1390

I make this function output different warning messages according to different inband event types. I hope the person in charge of the thread part can consider my suggestion.

Thanks!