### PR TITLE
fix:modify the generate_rust_analyzer to delete useless makefiles

### DIFF
--- a/scripts/generate_rust_analyzer.py
+++ b/scripts/generate_rust_analyzer.py
@@ -95,6 +95,12 @@ def generate_crates(srctree, objtree, sysroot_src, bindings_file):
         "exclude_dirs": [],
     }
 
+    def is_root_crate(build_file, target):
+        try:
+            return f"{target}.o" in open(build_file).read()
+        except FileNotFoundError:
+            return False
+    
     # Then, the rest outside of `rust/`.
     #
     # We explicitly mention the top-level folders we want to cover.
@@ -102,11 +108,9 @@ def generate_crates(srctree, objtree, sysroot_src, bindings_file):
         for path in (srctree / folder).rglob("*.rs"):
             logging.info("Checking %s", path)
             name = path.name.replace(".rs", "")
-
             # Skip those that are not crate roots.
-            if f"{name}.o" not in open(path.parent / "Makefile").read():
+            if not is_root_crate(path.parent / "Makefile", name):
                 continue
-
             logging.info("Adding %s", name)
             append_crate(
                 name,


### PR DESCRIPTION
The PR #55 points out that generate_rust_analyzer.py cannot function properly when the Makefiles are missing. This is due to the lack of handling for the case where the Makefile does not exist. The relevant code is as follows:
https://github.com/BUPT-OS/RROS/blob/129975ae0600ba00a548ac411591c60d291c807c/scripts/generate_rust_analyzer.py#L98-L119
The code attempts to open a file without checking for the existence of the Makefile, resulting in a FileNotFoundError when generating the `rust-project.json` for rust-analyzer. Since the Makefile in these directories serves no other purpose, I think handling the absence of Makefiles through exception catching is a better choice than providing empty Makefiles. The changes are as follows.
That's all.Thanks.
