### PR TITLE
rust: Kconfig: add config for RROS tests

### DIFF
--- a/kernel/rros/Kconfig
+++ b/kernel/rros/Kconfig
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 
 config RROS_OOB_NET
-        bool "Out-of-band networking (EXPERIMENTAL)"
+	bool "Out-of-band networking (EXPERIMENTAL)"
 	default n
 	select NET_OOB
 	select NET_SCHED
@@ -9,4 +9,16 @@ config RROS_OOB_NET
 	select INET
 	select VLAN_8021Q
 	help
-	This option enables preliminary networking support for Rros.
+		This option enables preliminary networking support for Rros.
+
+menuconfig RROS_TEST
+	bool "Open the test point of RROS"
+	default n
+	depends on Rros
+	help
+		Let the test code test whether RROS works properly when the system
+		starts. Turning on this CONFIG will slow down the startup.
+
+if RROS_TEST
+	source "kernel/rros/Kconfig.rros_test"
+endif

--- a/kernel/rros/Kconfig.rros_test
+++ b/kernel/rros/Kconfig.rros_test
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: GPL-2.0-only
+
+config RROS_SMP_TEST
+    bool "SMP test"
+	default n
+	help
+	    Test the SMP function of RROS.
+
+config RROS_TIMER_TEST
+    bool "Timer test"
+    default n
+    help
+        Test whether the timer in RROS is functioning properly.
+
+config RROS_DOUBLE_LINKED_LIST
+    bool "Double linked list test"
+    default n
+    help
+        Test whether the double linked list in RROS is functioning properly.
+
+config RROS_CLOCK_TEST
+    bool "Clock test"
+    default n
+    help
+        Test whether the clock in RROS is functioning properly.
+
+config RROS_THREAD_TEST
+    bool "Thread test"
+    default n
+    help
+        Test whether the thread in RROS is functioning properly.
+
+config RROS_WAIT_TEST
+    bool "RrosWaitQueue test"
+    default n
+    help
+        Test whether the wait queue in RROS is functioning properly.
+
+config RROS_MEM_TEST
+    bool "Memory test"
+    default n
+    help
+        Test whether the memory management in RROS is functioning properly.
+
+config RROS_LATENCY_TEST
+    bool "Latency test"
+    default n
+    help
+        Test the latmus of RROS.

--- a/kernel/rros/init.rs
+++ b/kernel/rros/init.rs
@@ -295,6 +295,7 @@ fn test_double_linked_list() {
     }
 }
 
+#[allow(dead_code)]
 fn test_thread() {
     thread_test::test_thread_context_switch();
     // thread_test::test_NetKthreadRunner();
@@ -327,11 +328,13 @@ fn test_fifo() {
         }
     }
 }
+#[allow(dead_code)]
 fn test_mem() {
     memory_test::mem_test();
 }
 
-fn test_lantency() {
+#[allow(dead_code)]
+fn test_latency() {
     rros::latmus::test_latmus();
 }
 
@@ -384,13 +387,21 @@ impl KernelModule for Rros {
         let res = init_core(); //*sysheap_size_arg.read()
         let fac_reg;
 
-        // test_timer();
-        // test_double_linked_list();
+        #[cfg(CONFIG_RROS_TIMER_TEST)]
+        test_timer();
 
-        // test_clock();
+        #[cfg(CONFIG_RROS_DOUBLE_LINKED_LIST)]
+        test_double_linked_list();
+
+        #[cfg(CONFIG_RROS_CLOCK_TEST)]
+        test_clock();
+
+        #[cfg(CONFIG_RROS_THREAD_TEST)]
         test_thread();
-        //test_double_linked_list();
-        // wait::wait_test();
+
+        #[cfg(CONFIG_RROS_WAIT_TEST)]
+        wait::wait_test();
+
         let ret = net::init();
         match ret {
             Ok(_o) => (),
@@ -400,7 +411,9 @@ impl KernelModule for Rros {
             }
         }
 
+        #[cfg(CONFIG_RROS_MEM_TEST)]
         test_mem();
+
         match res {
             Ok(_o) => {
                 pr_info!("Success boot the rros.");
@@ -411,8 +424,11 @@ impl KernelModule for Rros {
                 return Err(_e);
             }
         }
-        test_lantency();
 
+        #[cfg(CONFIG_RROS_LATENCY_TEST)]
+        test_latency();
+
+        #[cfg(CONFIG_RROS_SMP_TEST)]
         test_smp();
 
         // let mut rros_kthread1 = rros_kthread::new(fn1);

--- a/kernel/rros/memory_test.rs
+++ b/kernel/rros/memory_test.rs
@@ -5,6 +5,7 @@ use kernel::{
 use alloc::alloc::*;
 use alloc::alloc_rros::*;
 
+#[allow(dead_code)]
 pub fn mem_test() {
     // mem_test1();
     // mem_test2();

--- a/kernel/rros/rros/latmus.rs
+++ b/kernel/rros/rros/latmus.rs
@@ -5,8 +5,10 @@ use crate::{
 use kernel::prelude::*;
 use kernel::{c_str, c_types, ktime};
 
+#[allow(dead_code)]
 static mut KTHREAD_RUNNER_1: KthreadRunner = KthreadRunner::new_empty();
 
+#[allow(dead_code)]
 fn kthread_handler(ptr: *mut c_types::c_void) {
     // thread::rros_sleep(10000000000);
     let k_runner = unsafe { &mut *(ptr as *mut KthreadRunner) };
@@ -115,6 +117,7 @@ fn kthread_handler(ptr: *mut c_types::c_void) {
     // }
 }
 
+#[allow(dead_code)]
 pub fn test_latmus() {
     unsafe {
         KTHREAD_RUNNER_1.init(
@@ -134,6 +137,7 @@ pub fn test_latmus() {
     }
 }
 
+#[allow(dead_code)]
 fn add_measurement_sample(runner: &mut KthreadRunner, timestamp: ktime::KtimeT) -> i32 {
     let period = runner.2.period as i64;
     let mut state = &mut runner.2.state;

--- a/kernel/rros/thread.rs
+++ b/kernel/rros/thread.rs
@@ -61,7 +61,9 @@ extern "C" {
     fn rust_helper_preempt_enable();
     #[allow(dead_code)]
     fn rust_helper_preempt_disable();
+    #[allow(dead_code)]
     fn rust_helper_hard_local_irq_save() -> c_types::c_ulong;
+    #[allow(dead_code)]
     fn rust_helper_hard_local_irq_restore(flags: c_types::c_ulong);
     // fn rust_helper_doveail_mm_state() -> *mut bindings::oob_mm_state;
 }
@@ -2499,6 +2501,7 @@ impl KthreadRunner {
     }
 }
 
+#[allow(dead_code)]
 pub fn rros_set_period(
     clock: &mut clock::RrosClock,
     idate: ktime::KtimeT,
@@ -2570,6 +2573,7 @@ pub fn rros_set_period(
     // EXPORT_SYMBOL_GPL(rros_set_period);
 }
 
+#[allow(dead_code)]
 pub fn rros_wait_period() -> Result<usize> {
     let curr = rros_current();
     let thread = unsafe { Arc::from_raw(curr as *mut SpinLock<RrosThread>) };
@@ -2652,6 +2656,7 @@ pub fn rros_wait_period() -> Result<usize> {
     // EXPORT_SYMBOL_GPL(rros_wait_period);
 }
 
+#[allow(dead_code)]
 fn rros_get_timer_overruns(timer: Arc<SpinLock<timer::RrosTimer>>) -> Result<u32> {
     // unsigned long rros_get_timer_overruns(struct rros_timer *timer)
     // {

--- a/kernel/rros/thread_test.rs
+++ b/kernel/rros/thread_test.rs
@@ -26,9 +26,12 @@ use kernel::{c_str, prelude::*};
 // // static mut KTHREAD_RUNNER_1:Option<> = ;
 // static mut KTHREAD_RUNNER_1: Option<KthreadRunner> = None;
 // static mut KTHREAD_RUNNER_2: Option<KthreadRunner> = None;
+#[allow(dead_code)]
 static mut KTHREAD_RUNNER_1: KthreadRunner = KthreadRunner::new_empty();
+#[allow(dead_code)]
 static mut KTHREAD_RUNNER_2: KthreadRunner = KthreadRunner::new_empty();
 
+#[allow(dead_code)]
 pub fn test_thread_context_switch() {
     let rq = this_rros_rq();
 
@@ -209,6 +212,7 @@ pub fn test_thread_context_switch() {
 //     1 as c_types::c_int
 // }
 
+#[allow(dead_code)]
 fn kfn_1() {
     for _i in 0..10 {
         pr_emerg!("hello! from rros~~~~~~~~~~~~");
@@ -264,6 +268,7 @@ fn kfn_1() {
 
 // static mut aa:i32 = 0;
 // static mut aa:i32 = 0;
+#[allow(dead_code)]
 pub fn kfn_2() {
     //     for t in 0..1000000 {
     //         // thread::rros_sleep(1000000000);


### PR DESCRIPTION
Make the RROS tests configurable to avoid the default execution of the tests during system startup, which causes the system startup to take too long time.

This PR is intended to solve https://github.com/BUPT-OS/RROS/issues/56.